### PR TITLE
Add asyncio version of run_query

### DIFF
--- a/pyblazing/__init__.py
+++ b/pyblazing/__init__.py
@@ -15,6 +15,7 @@ from .api import create_table
 from .api import ResultSetHandle
 from .api import _get_client
 
+from .connector import PyConnector
 from .connector.utils import is_caller_async
 from .api import run_query as run_query_sync
 from .aio import run_query as run_query_async
@@ -43,6 +44,6 @@ def run_query(sql, tables):
     >>> type(result)
     cudf.dataframe.DataFrame
     """
-    if is_caller_async():
+    if PyConnector.asyncio_enabled and is_caller_async():
         return run_query_async(sql, tables)
     return run_query_sync(sql, tables)

--- a/pyblazing/__init__.py
+++ b/pyblazing/__init__.py
@@ -1,4 +1,3 @@
-from .api import run_query
 from .api import run_query_get_token
 from .api import run_query_filesystem_get_token
 from .api import run_query_get_results
@@ -15,3 +14,35 @@ from .api import create_table
 
 from .api import ResultSetHandle
 from .api import _get_client
+
+from .connector.utils import is_caller_async
+from .api import run_query as run_query_sync
+from .aio import run_query as run_query_async
+
+def run_query(sql, tables):
+    """
+    Run a SQL query over a dictionary of GPU DataFrames.
+    Parameters
+    ----------
+    sql : str
+        The SQL query.
+    tables : dict[str]:GPU ``DataFrame``
+        A dictionary where each key is the table name and each value is the
+        associated GPU ``DataFrame`` object.
+    Returns
+    -------
+    A GPU ``DataFrame`` object that contains the SQL query result.
+    Examples
+    --------
+    >>> import cudf as gd
+    >>> import pyblazing
+    >>> products = gd.DataFrame({'month': [2, 8, 11], 'sales': [12.1, 20.6, 13.79]})
+    >>> cats = gd.DataFrame({'age': [12, 28, 19], 'weight': [5.3, 9, 7.68]})
+    >>> tables = {'products': products, 'cats': cats}
+    >>> result = pyblazing.run_query('select * from products, cats limit 2', tables)
+    >>> type(result)
+    cudf.dataframe.DataFrame
+    """
+    if is_caller_async():
+        return run_query_async(sql, tables)
+    return run_query_sync(sql, tables)

--- a/pyblazing/aio.py
+++ b/pyblazing/aio.py
@@ -1,0 +1,122 @@
+import time
+
+from blazingdb.protocol.errors import Error
+from .api import (_get_client, _to_table_group, _get_table_def_from_gdf, ResultSetHandle, _createResultSetIPCHandles)
+
+async def run_query(sql, tables):
+    """
+    Run a SQL query over a dictionary of GPU DataFrames.
+    Parameters
+    ----------
+    sql : str
+        The SQL query.
+    tables : dict[str]:GPU ``DataFrame``
+        A dictionary where each key is the table name and each value is the
+        associated GPU ``DataFrame`` object.
+    Returns
+    -------
+    A GPU ``DataFrame`` object that contains the SQL query result.
+    Examples
+    --------
+    >>> import cudf as gd
+    >>> import pyblazing
+    >>> products = gd.DataFrame({'month': [2, 8, 11], 'sales': [12.1, 20.6, 13.79]})
+    >>> cats = gd.DataFrame({'age': [12, 28, 19], 'weight': [5.3, 9, 7.68]})
+    >>> tables = {'products': products, 'cats': cats}
+    >>> result = pyblazing.run_query('select * from products, cats limit 2', tables)
+    >>> type(result)
+    cudf.dataframe.DataFrame
+    """
+    return await _private_run_query(sql, tables)
+
+
+async def _private_run_query(sql, tables):
+    return await _run_query_get_results(await _run_query_get_token(sql, tables))
+
+async def _reset_table(client, table, gdf):
+    await client.run_ddl_drop_table(table, 'main')
+    cols, types = _get_table_def_from_gdf(gdf)
+    await client.run_ddl_create_table(table, cols, types, 'main')
+
+async def _run_query_get_results(metaToken):
+
+    error_message = ''
+
+    try:
+        resultSet, ipchandles = await _private_get_result(
+            metaToken["resultToken"],
+            metaToken["interpreter_path"],
+            metaToken["interpreter_port"]
+        )
+
+        totalTime = (time.time() - metaToken["startTime"]) * 1000  # in milliseconds
+        return_result = ResultSetHandle(
+            resultSet.columns, 
+            resultSet.columnTokens, 
+            metaToken["resultToken"],
+            metaToken["interpreter_path"],
+            metaToken["interpreter_port"],
+            ipchandles,
+            metaToken["client"],
+            metaToken["calciteTime"],
+            resultSet.metadata.time,
+            totalTime,
+            ''
+        )
+        return return_result
+    except (SyntaxError, RuntimeError, ValueError, ConnectionRefusedError, AttributeError) as error:
+        print(error)
+        error_message = error
+    except Error as error:
+        print(error)
+        error_message = str(error)
+    except Exception as error:
+        print(error)
+        error_message = "Unexpected error on " + _run_query_get_results.__name__ + ", " + str(error)
+
+    return_result = ResultSetHandle(None, None,
+        metaToken["resultToken"],
+        metaToken["interpreter_path"],
+        metaToken["interpreter_port"], None,
+        metaToken["client"],
+        metaToken["calciteTime"],
+        0, 0, error_message
+    )
+    return return_result
+
+
+async def _private_get_result(resultToken, interpreter_path, interpreter_port):
+    return _createResultSetIPCHandles(await _get_client()._get_result(resultToken, interpreter_path, interpreter_port))
+
+
+#@exceptions_wrapper
+async def _run_query_get_token(sql, tables):
+    startTime = time.time()
+
+    resultToken = 0
+    interpreter_path = None
+    interpreter_port = None
+    calciteTime = 0
+    error_message = ''
+
+    try:
+        client = _get_client()
+
+        for table, gdf in tables.items():
+            await _reset_table(client, table, gdf)
+
+        resultToken, interpreter_path, interpreter_port, calciteTime = \
+            await client.run_dml_query_token(sql, _to_table_group(tables))
+
+    except (SyntaxError, RuntimeError, ValueError, ConnectionRefusedError, AttributeError) as error:
+        error_message = error
+    except Error as error:
+        error_message = str(error)
+    except Exception as error:
+        error_message = "Unexpected error on " + _run_query_get_token.__name__ + ", " + str(error)
+
+    if error_message is not '':
+        print(error_message)
+
+    metaToken = {"client" : client, "resultToken" : resultToken, "interpreter_path" : interpreter_path, "interpreter_port" : interpreter_port, "startTime" : startTime, "calciteTime" : calciteTime}
+    return metaToken

--- a/pyblazing/aio.py
+++ b/pyblazing/aio.py
@@ -48,13 +48,6 @@ async def _reset_table(client, table, gdf):
     cols, types = _get_table_def_from_gdf(gdf)
     await client.run_ddl_create_table(table, cols, types, 'main')
 
-def _reset_tables_async(client, tables):
-    coroutines = []
-    for table, gdf in tables.items():
-        co = _reset_table(client, table, gdf)
-        coroutines.append(asyncio.shield(co))
-    return asyncio.shield(asyncio.gather(*coroutines))
-
 async def _run_query_get_results(metaToken):
 
     error_message = ''
@@ -122,7 +115,8 @@ async def _run_query_get_token(sql, tables):
     try:
         client = _get_client()
 
-        await _reset_tables_async(client, tables)
+        for table, gdf in tables.items():
+            await _reset_table(client, table, gdf)
 
         resultToken, interpreter_path, interpreter_port, calciteTime = \
             await client.run_dml_query_token(sql, _to_table_group(tables))

--- a/pyblazing/aio.py
+++ b/pyblazing/aio.py
@@ -1,4 +1,5 @@
 import time
+import asyncio
 import traceback
 
 from blazingdb.protocol.errors import Error
@@ -47,6 +48,12 @@ async def _reset_table(client, table, gdf):
     cols, types = _get_table_def_from_gdf(gdf)
     await client.run_ddl_create_table(table, cols, types, 'main')
 
+def _reset_tables_async(client, tables):
+    coroutines = []
+    for table, gdf in tables.items():
+        co = _reset_table(client, table, gdf)
+        coroutines.append(asyncio.shield(co))
+    return asyncio.shield(asyncio.gather(*coroutines))
 
 async def _run_query_get_results(metaToken):
 
@@ -115,8 +122,7 @@ async def _run_query_get_token(sql, tables):
     try:
         client = _get_client()
 
-        for table, gdf in tables.items():
-            await _reset_table(client, table, gdf)
+        await _reset_tables_async(client, tables)
 
         resultToken, interpreter_path, interpreter_port, calciteTime = \
             await client.run_dml_query_token(sql, _to_table_group(tables))

--- a/pyblazing/api.py
+++ b/pyblazing/api.py
@@ -82,7 +82,10 @@ class ResultSetHandle:
         if self.columns is not None:
             for col in self.columns._cols.values():
                 if isinstance(col._column, StringColumn):
-                    nvstrings.free(col._column._data)
+                    try:
+                        nvstrings.free(col._column._data)
+                    except:
+                        pass
             del self.columns
         if self.handle is not None:
             for ipch in self.handle:

--- a/pyblazing/api.py
+++ b/pyblazing/api.py
@@ -1,3 +1,4 @@
+import traceback
 import cudf as gd
 
 import blazingdb.protocol
@@ -553,6 +554,7 @@ def _run_query_get_token(sql, tables):
     except Error as error:
         error_message = str(error)
     except Exception as error:
+        print(traceback.print_exc())
         error_message = "Unexpected error on " + _run_query_get_token.__name__ + ", " + str(error)
 
     if error_message is not '':

--- a/pyblazing/connector/__init__.py
+++ b/pyblazing/connector/__init__.py
@@ -1,0 +1,125 @@
+from .utils import bind_request
+from .connect import (create_connect_request, handle_connect_response)
+from .run_dml_load_parquet_schema import (create_run_dml_load_parquet_schema_request, handle_run_dml_load_parquet_schema_response)
+from .run_dml_load_csv_schema import (create_run_dml_load_csv_schema_request, handle_run_dml_load_csv_schema_response)
+from .run_dml_query_token import (create_run_dml_query_token_request, handle_run_dml_query_token_response)
+from .run_dml_query_filesystem_token import (create_run_dml_query_filesystem_token_request, handle_run_dml_query_filesystem_token_response)
+from .run_dml_query import (create_run_dml_query_request, handle_run_dml_query_response)
+from .run_ddl_create_table import (create_run_ddl_create_table_request, handle_run_ddl_create_table_response)
+from .run_ddl_drop_table import (create_run_ddl_drop_table_request, handle_run_ddl_drop_table_response)
+from .close_connection import (create_close_connection_request, handle_close_connection_response)
+from .free_memory import (create_free_memory_request, handle_free_memory_response)
+from .free_result import (create_free_result_request, handle_free_result_response)
+from ._get_result import (create__get_result_request, handle__get_result_response)
+
+class PyConnector:
+
+    def __init__(self, orchestrator_path, orchestrator_port):
+        self._path = orchestrator_path
+        self._port = orchestrator_port
+        self._interpreter = Interpreter(self)
+        self._orchestrator = Orchestrator(self)
+
+    def __del__(self):
+        try:
+            print("CLOSING CONNECTION")
+            self.close_connection()
+        except:
+            print("Can't close connection, probably it was lost")
+        del self._interpreter
+        del self._orchestrator
+
+    def connect(self):
+        return self._orchestrator.connect()
+    def run_dml_load_parquet_schema(self, path):
+        return self._orchestrator.run_dml_load_parquet_schema(path)
+    def run_dml_load_csv_schema(self, path, names, dtypes, delimiter = '|', line_terminator='\n', skip_rows=0):
+        return self._orchestrator.run_dml_load_csv_schema(path, names, dtypes, delimiter = '|', line_terminator='\n', skip_rows=0)
+    def run_dml_query_token(self, query, tableGroup):
+        return self._orchestrator.run_dml_query_token(query, tableGroup)
+    def run_dml_query_filesystem_token(self, query, tableGroup):
+        return self._orchestrator.run_dml_query_filesystem_token(query, tableGroup)
+    def run_dml_query(self, query, tableGroup):
+        return self._orchestrator.run_dml_query(query, tableGroup)
+    def run_ddl_create_table(self, tableName, columnNames, columnTypes, dbName):
+        return self._orchestrator.run_ddl_create_table(tableName, columnNames, columnTypes, dbName)
+    def run_ddl_drop_table(self, tableName, dbName):
+        return self._orchestrator.run_ddl_drop_table(tableName, dbName)
+    def close_connection(self):
+        return self._orchestrator.close_connection()
+    def free_memory(self, result_token, interpreter_path, interpreter_port):
+        self._interpreter._path = interpreter_path
+        self._interpreter._port = interpreter_port
+        return self._interpreter.free_memory(result_token)
+    def free_result(self, result_token, interpreter_path, interpreter_port):
+        self._interpreter._path = interpreter_path
+        self._interpreter._port = interpreter_port
+        return self._interpreter.free_result(result_token)
+    def _get_result(self, result_token, interpreter_path, interpreter_port):
+        self._interpreter._path = interpreter_path
+        self._interpreter._port = interpreter_port
+        return self._interpreter._get_result(result_token)
+
+class Orchestrator:
+    def __init__(self, connector):
+        self._connector = connector
+    @property
+    def _path(self):
+        return self._connector._path
+    @property
+    def _port(self):
+        return self._connector._port
+    @property
+    def accessToken(self):
+        return self._connector.accessToken
+    @accessToken.setter
+    def accessToken(self, accessToken):
+        self._connector.accessToken = accessToken
+    def connect(self):
+        pass
+    def run_dml_load_parquet_schema(self, path):
+        pass
+    def run_dml_load_csv_schema(self, path, names, dtypes, delimiter = '|', line_terminator='\n', skip_rows=0):
+        pass
+    def run_dml_query_token(self, query, tableGroup):
+        pass
+    def run_dml_query_filesystem_token(self, query, tableGroup):
+        pass
+    def run_dml_query(self, query, tableGroup):
+        pass
+    def run_ddl_create_table(self, tableName, columnNames, columnTypes, dbName):
+        pass
+    def run_ddl_drop_table(self, tableName, dbName):
+        pass
+    def close_connection(self):
+        pass
+
+class Interpreter:
+    def __init__(self, connector):
+        self._connector = connector
+    @property
+    def accessToken(self):
+        return self._connector.accessToken
+    @accessToken.setter
+    def accessToken(self, accessToken):
+        self._connector.accessToken = accessToken
+    def free_memory(self, result_token):
+        pass
+    def free_result(self, result_token):
+        pass
+    def _get_result(self, result_token):
+        pass
+
+setattr(Orchestrator, 'connect', bind_request(create_connect_request, handle_connect_response))
+setattr(Orchestrator, 'run_dml_load_parquet_schema', bind_request(create_run_dml_load_parquet_schema_request, handle_run_dml_load_parquet_schema_response))
+setattr(Orchestrator, 'run_dml_load_csv_schema', bind_request(create_run_dml_load_csv_schema_request, handle_run_dml_load_csv_schema_response))
+setattr(Orchestrator, 'run_dml_query_token', bind_request(create_run_dml_query_token_request, handle_run_dml_query_token_response))
+setattr(Orchestrator, 'run_dml_query_filesystem_token', bind_request(create_run_dml_query_filesystem_token_request, handle_run_dml_query_filesystem_token_response))
+setattr(Orchestrator, 'run_dml_query', bind_request(create_run_dml_query_request, handle_run_dml_query_response))
+setattr(Orchestrator, 'run_ddl_create_table', bind_request(create_run_ddl_create_table_request, handle_run_ddl_create_table_response))
+setattr(Orchestrator, 'run_ddl_drop_table', bind_request(create_run_ddl_drop_table_request, handle_run_ddl_drop_table_response))
+setattr(Orchestrator, 'close_connection', bind_request(create_close_connection_request, handle_close_connection_response))
+
+setattr(Interpreter, 'free_memory', bind_request(create_free_memory_request, handle_free_memory_response))
+setattr(Interpreter, 'free_result', bind_request(create_free_result_request, handle_free_result_response))
+setattr(Interpreter, '_get_result', bind_request(create__get_result_request, handle__get_result_response))

--- a/pyblazing/connector/__init__.py
+++ b/pyblazing/connector/__init__.py
@@ -14,20 +14,14 @@ from ._get_result import (create__get_result_request, handle__get_result_respons
 
 class PyConnector:
 
+    asyncio_enabled = False
+
     def __init__(self, orchestrator_path, orchestrator_port):
         self._path = orchestrator_path
         self._port = orchestrator_port
         self._interpreter = Interpreter(self)
         self._orchestrator = Orchestrator(self)
 
-    def __del__(self):
-        try:
-            print("CLOSING CONNECTION")
-            self.close_connection()
-        except:
-            print("Can't close connection, probably it was lost")
-        del self._interpreter
-        del self._orchestrator
 
     def connect(self):
         return self._orchestrator.connect()
@@ -70,6 +64,9 @@ class Orchestrator:
     def _port(self):
         return self._connector._port
     @property
+    def asyncio_enabled(self):
+        return self._connector.asyncio_enabled
+    @property
     def accessToken(self):
         return self._connector.accessToken
     @accessToken.setter
@@ -97,6 +94,9 @@ class Orchestrator:
 class Interpreter:
     def __init__(self, connector):
         self._connector = connector
+    @property
+    def asyncio_enabled(self):
+        return self._connector.asyncio_enabled
     @property
     def accessToken(self):
         return self._connector.accessToken

--- a/pyblazing/connector/_get_result.py
+++ b/pyblazing/connector/_get_result.py
@@ -1,0 +1,19 @@
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.interpreter import (InterpreterMessage, GetResultRequestSchema, GetQueryResultFrom)
+from blazingdb.protocol.transport.channel import (MakeRequestBuffer, ResponseSchema)
+
+
+def create__get_result_request(self, result_token):
+    getResultRequest = GetResultRequestSchema(resultToken=result_token)
+    return MakeRequestBuffer(InterpreterMessage.GetResult, self.accessToken, getResultRequest)
+
+
+def handle__get_result_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        raise ValueError('Error status')
+    queryResult = GetQueryResultFrom(response.payload)
+    if queryResult.metadata.status.decode() == "Error":
+        raise Error(queryResult.metadata.message.decode('utf-8'))
+    return queryResult
+

--- a/pyblazing/connector/close_connection.py
+++ b/pyblazing/connector/close_connection.py
@@ -1,0 +1,19 @@
+from blazingdb.protocol.errors import Error
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.orchestrator import (AuthRequestSchema, AuthResponseSchema, OrchestratorMessageType)
+from blazingdb.protocol.transport.channel import (MakeRequestBuffer, ResponseSchema, ResponseErrorSchema)
+
+def create_close_connection_request(self):
+    # TODO find a way to print only for debug mode (add verbose arg)
+    # print("close connection")
+    return MakeRequestBuffer(OrchestratorMessageType.AuthClose, self.accessToken, AuthRequestSchema())
+
+
+def handle_close_connection_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        errorResponse = ResponseErrorSchema.From(response.payload)
+        raise Error(errorResponse.errors.decode('utf-8'))
+    # TODO find a way to print only for debug mode (add verbose arg)
+    # print(response.status)
+

--- a/pyblazing/connector/connect.py
+++ b/pyblazing/connector/connect.py
@@ -1,0 +1,22 @@
+from blazingdb.protocol.errors import Error
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.orchestrator import (AuthRequestSchema, AuthResponseSchema, OrchestratorMessageType)
+from blazingdb.protocol.transport.channel import (MakeAuthRequestBuffer, ResponseSchema, ResponseErrorSchema)
+
+def create_connect_request(self):
+    # TODO find a way to print only for debug mode (add verbose arg)
+    #print("open connection")
+    return MakeAuthRequestBuffer(OrchestratorMessageType.AuthOpen, AuthRequestSchema())
+
+def handle_connect_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        errorResponse = ResponseErrorSchema.From(response.payload)
+        print(errorResponse.errors)
+        raise Error(errorResponse.errors.decode('utf-8'))
+    responsePayload = AuthResponseSchema.From(response.payload)
+    # TODO find a way to print only for debug mode (add verbose arg)
+    # print(responsePayload.accessToken)
+    self.accessToken = responsePayload.accessToken
+    return responsePayload
+

--- a/pyblazing/connector/free_memory.py
+++ b/pyblazing/connector/free_memory.py
@@ -1,0 +1,19 @@
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.interpreter import (InterpreterMessage, GetResultRequestSchema)
+from blazingdb.protocol.transport.channel import (MakeRequestBuffer, ResponseSchema)
+
+
+def create_free_memory_request(self, result_token=None):
+    # (ptaylor) TODO: is this correct?
+    if result_token is None:
+        result_token = 2433423
+    return MakeRequestBuffer(InterpreterMessage.FreeMemory, self.accessToken, GetResultRequestSchema(resultToken=result_token))
+
+
+def handle_free_memory_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        raise ValueError('Error status')
+    # TODO find a way to print only for debug mode (add verbose arg)
+    #print('free result OK!')
+

--- a/pyblazing/connector/free_result.py
+++ b/pyblazing/connector/free_result.py
@@ -1,0 +1,17 @@
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.interpreter import (InterpreterMessage, GetResultRequestSchema)
+from blazingdb.protocol.transport.channel import (MakeRequestBuffer, ResponseSchema)
+
+
+def create_free_result_request(self, result_token):
+    getResultRequest = GetResultRequestSchema(resultToken=result_token)
+    return MakeRequestBuffer(InterpreterMessage.FreeResult, self.accessToken, getResultRequest)
+
+
+def handle_free_result_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        raise ValueError('Error status')
+    # TODO find a way to print only for debug mode (add verbose arg)
+    #print('free result OK!')
+

--- a/pyblazing/connector/run_ddl_create_table.py
+++ b/pyblazing/connector/run_ddl_create_table.py
@@ -1,0 +1,31 @@
+from blazingdb.protocol.errors import Error
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.orchestrator import (DDLCreateTableRequestSchema, OrchestratorMessageType)
+from blazingdb.protocol.transport.channel import (MakeRequestBuffer, ResponseSchema, ResponseErrorSchema)
+
+
+def create_run_ddl_create_table_request(self, tableName, columnNames, columnTypes, dbName):
+    # TODO find a way to print only for debug mode (add verbose arg)
+    # print('create table: ' + tableName)
+    # print(columnNames)
+    # print(columnTypes)
+    # print(dbName)
+    dmlRequestSchema = DDLCreateTableRequestSchema(name=tableName,
+                                                   columnNames=columnNames,
+                                                   columnTypes=columnTypes,
+                                                   dbName=dbName)
+
+    # TODO find a way to print only for debug mode (add verbose arg)
+    # print(dmlRequestSchema)
+    return MakeRequestBuffer(OrchestratorMessageType.DDL_CREATE_TABLE, self.accessToken, dmlRequestSchema)
+
+
+def handle_run_ddl_create_table_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        errorResponse = ResponseErrorSchema.From(response.payload)
+        raise Error(errorResponse.errors.decode('utf-8'))
+    # TODO find a way to print only for debug mode (add verbose arg)
+    # print(response.status)
+    return response.status
+

--- a/pyblazing/connector/run_ddl_drop_table.py
+++ b/pyblazing/connector/run_ddl_drop_table.py
@@ -1,0 +1,21 @@
+from blazingdb.protocol.errors import Error
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.orchestrator import (DDLDropTableRequestSchema, OrchestratorMessageType)
+from blazingdb.protocol.transport.channel import (MakeRequestBuffer, ResponseSchema, ResponseErrorSchema)
+
+def create_run_ddl_drop_table_request(self, tableName, dbName):
+    # TODO find a way to print only for debug mode (add verbose arg)
+    #print('drop table: ' + tableName)
+    dmlRequestSchema = DDLDropTableRequestSchema(name=tableName, dbName=dbName)
+    return MakeRequestBuffer(OrchestratorMessageType.DDL_DROP_TABLE, self.accessToken, dmlRequestSchema)
+
+
+def handle_run_ddl_drop_table_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        errorResponse = ResponseErrorSchema.From(response.payload)
+        raise Error(errorResponse.errors.decode('utf-8'))
+    # TODO find a way to print only for debug mode (add verbose arg)
+    # print(response.status)
+    return response.status
+

--- a/pyblazing/connector/run_dml_load_csv_schema.py
+++ b/pyblazing/connector/run_dml_load_csv_schema.py
@@ -1,0 +1,23 @@
+from blazingdb.protocol.errors import Error
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.io import CsvFileSchema
+from blazingdb.protocol.transport.channel import (MakeRequestBuffer, ResponseSchema, ResponseErrorSchema)
+
+def create_run_dml_load_csv_schema_request(self, path, names, dtypes, delimiter = '|', line_terminator='\n', skip_rows=0):
+    print('load csv file')
+    requestSchema = CsvFileSchema(path=path, delimiter=delimiter, lineTerminator=line_terminator, skipRows=skip_rows, names=names, dtypes=dtypes)
+    return MakeRequestBuffer(OrchestratorMessageType.LoadCsvSchema, self.accessToken, requestSchema)
+
+
+def handle_run_dml_load_csv_schema_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        errorResponse = ResponseErrorSchema.From(response.payload)
+        if b'SqlSyntaxException' in errorResponse.errors:
+            raise SyntaxError(errorResponse.errors.decode('utf-8'))
+        elif b'SqlValidationException' in errorResponse.errors:
+            raise ValueError(errorResponse.errors.decode('utf-8'))
+        raise Error(errorResponse.errors.decode('utf-8'))
+    dmlResponseDTO = DMLResponseSchema.From(response.payload)
+    return dmlResponseDTO.resultToken, dmlResponseDTO.nodeConnection.path.decode('utf8'), dmlResponseDTO.nodeConnection.port
+

--- a/pyblazing/connector/run_dml_load_parquet_schema.py
+++ b/pyblazing/connector/run_dml_load_parquet_schema.py
@@ -1,0 +1,25 @@
+from blazingdb.protocol.errors import Error
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.io import ParquetFileSchema
+from blazingdb.protocol.orchestrator import (DMLResponseSchema, OrchestratorMessageType)
+from blazingdb.protocol.transport.channel import (MakeRequestBuffer, ResponseSchema, ResponseErrorSchema)
+
+def create_run_dml_load_parquet_schema_request(self, path):
+    print('load parquet file')
+    ## todo use rowGroupIndices, and columnIndices, someway??
+    requestSchema = ParquetFileSchema(path=path, rowGroupIndices=[], columnIndices=[])
+    return MakeRequestBuffer(OrchestratorMessageType.LoadParquetSchema, self.accessToken, requestSchema)
+
+
+def handle_run_dml_load_parquet_schema_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        errorResponse = ResponseErrorSchema.From(response.payload)
+        if b'SqlSyntaxException' in errorResponse.errors:
+            raise SyntaxError(errorResponse.errors.decode('utf-8'))
+        elif b'SqlValidationException' in errorResponse.errors:
+            raise ValueError(errorResponse.errors.decode('utf-8'))
+        raise Error(errorResponse.errors.decode('utf-8'))
+    dmlResponseDTO = DMLResponseSchema.From(response.payload)
+    return dmlResponseDTO.resultToken, dmlResponseDTO.nodeConnection.path, dmlResponseDTO.nodeConnection.port
+

--- a/pyblazing/connector/run_dml_query.py
+++ b/pyblazing/connector/run_dml_query.py
@@ -1,0 +1,25 @@
+from blazingdb.protocol.errors import Error
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.orchestrator import (BuildDMLRequestSchema, DMLResponseSchema, OrchestratorMessageType)
+from blazingdb.protocol.transport.channel import (MakeRequestBuffer, ResponseSchema, ResponseErrorSchema)
+
+
+def create_run_dml_query_request(self, query, tableGroup):
+    # TODO find a way to print only for debug mode (add verbose arg)
+    # print(query)
+    dmlRequestSchema = BuildDMLRequestSchema(query, tableGroup)
+    return MakeRequestBuffer(OrchestratorMessageType.DML, self.accessToken, dmlRequestSchema)
+
+
+def handle_run_dml_query_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        errorResponse = ResponseErrorSchema.From(response.payload)
+        raise Error(errorResponse.errors.decode('utf-8'))
+    dmlResponseDTO = DMLResponseSchema.From(response.payload)
+    return self._get_result(
+        dmlResponseDTO.resultToken,
+        dmlResponseDTO.nodeConnection.path,
+        dmlResponseDTO.nodeConnection.port
+    )
+

--- a/pyblazing/connector/run_dml_query_filesystem_token.py
+++ b/pyblazing/connector/run_dml_query_filesystem_token.py
@@ -1,0 +1,24 @@
+from blazingdb.protocol.errors import Error
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.io import BuildFileSystemDMLRequestSchema
+from blazingdb.protocol.orchestrator import (BuildDMLRequestSchema, DMLResponseSchema, OrchestratorMessageType)
+from blazingdb.protocol.transport.channel import (MakeRequestBuffer, ResponseSchema, ResponseErrorSchema)
+
+
+def create_run_dml_query_filesystem_token_request(self, query, tableGroup):
+    dmlRequestSchema = BuildFileSystemDMLRequestSchema(query, tableGroup)
+    return MakeRequestBuffer(OrchestratorMessageType.DML_FS, self.accessToken, dmlRequestSchema)
+
+
+def handle_run_dml_query_filesystem_token_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        errorResponse = ResponseErrorSchema.From(response.payload)
+        if b'SqlSyntaxException' in errorResponse.errors:
+            raise SyntaxError(errorResponse.errors.decode('utf-8'))
+        elif b'SqlValidationException' in errorResponse.errors:
+            raise ValueError(errorResponse.errors.decode('utf-8'))
+        raise Error(errorResponse.errors.decode('utf-8'))
+    dmlResponseDTO = DMLResponseSchema.From(response.payload)
+    return dmlResponseDTO.resultToken, dmlResponseDTO.nodeConnection.path.decode('utf8'), dmlResponseDTO.nodeConnection.port, dmlResponseDTO.calciteTime
+

--- a/pyblazing/connector/run_dml_query_token.py
+++ b/pyblazing/connector/run_dml_query_token.py
@@ -1,0 +1,23 @@
+from blazingdb.protocol.errors import Error
+from blazingdb.messages.blazingdb.protocol.Status import Status
+from blazingdb.protocol.orchestrator import (BuildDMLRequestSchema, DMLResponseSchema, OrchestratorMessageType)
+from blazingdb.protocol.transport.channel import (MakeRequestBuffer, ResponseSchema, ResponseErrorSchema)
+
+
+def create_run_dml_query_token_request(self, query, tableGroup):
+    dmlRequestSchema = BuildDMLRequestSchema(query, tableGroup)
+    return MakeRequestBuffer(OrchestratorMessageType.DML, self.accessToken, dmlRequestSchema)
+
+
+def handle_run_dml_query_token_response(self, response_buffer):
+    response = ResponseSchema.From(response_buffer)
+    if response.status == Status.Error:
+        errorResponse = ResponseErrorSchema.From(response.payload)
+        if b'SqlSyntaxException' in errorResponse.errors:
+            raise SyntaxError(errorResponse.errors.decode('utf-8'))
+        elif b'SqlValidationException' in errorResponse.errors:
+            raise ValueError(errorResponse.errors.decode('utf-8'))
+        raise Error(errorResponse.errors.decode('utf-8'))
+    dmlResponseDTO = DMLResponseSchema.From(response.payload)
+    return dmlResponseDTO.resultToken, dmlResponseDTO.nodeConnection.path.decode('utf8'), dmlResponseDTO.nodeConnection.port, dmlResponseDTO.calciteTime
+

--- a/pyblazing/connector/utils.py
+++ b/pyblazing/connector/utils.py
@@ -31,7 +31,6 @@ def is_caller_async():
     """Figure out who's calling."""
     # Get the calling frame
     caller = inspect.currentframe().f_back.f_back
-    original_caller = caller
     while caller:
         # Pull the function name from FrameInfo
         func_name = inspect.getframeinfo(caller)[2]

--- a/pyblazing/connector/utils.py
+++ b/pyblazing/connector/utils.py
@@ -1,0 +1,70 @@
+import inspect
+from blazingdb.protocol import Client, AsyncClient, UnixSocketConnection
+
+def bind_request(create_request, handle_response):
+
+    def do_request(self, *args, **kwargs):
+        request_buffer = create_request(self, *args, **kwargs)
+        connection = UnixSocketConnection(self._path)
+        return Client(connection).send(request_buffer)
+
+    async def do_request_async(self, *args, **kwargs):
+        request_buffer = create_request(self, *args, **kwargs)
+        connection = UnixSocketConnection(self._path)
+        return await AsyncClient(connection).send(request_buffer)
+
+    async def handle_response_async(self, response_coroutine):
+        result = handle_response(self, await response_coroutine)
+        while is_awaitable(result):
+            result = await result
+        return result
+
+    def request(self, *args, **kwargs):
+        if is_caller_async():
+            return handle_response_async(self, do_request_async(self, *args, **kwargs))
+        return handle_response(self, do_request(self, *args, **kwargs))
+
+    return request
+
+
+def is_caller_async():
+    """Figure out who's calling."""
+    # Get the calling frame
+    caller = inspect.currentframe().f_back.f_back
+    original_caller = caller
+    while caller:
+        # Pull the function name from FrameInfo
+        func_name = inspect.getframeinfo(caller)[2]
+        # Get the function object
+        f = caller.f_locals.get(func_name, caller.f_globals.get(func_name))
+        # If there's any indication that the function object is a 
+        # coroutine, return True. inspect.iscoroutinefunction() should
+        # be all we need, the rest are here to illustrate.
+        if is_async_thing(f):
+            return True
+        caller = caller.f_back
+    return False
+
+
+def is_async_thing(thing):
+    return is_async_func(thing) or is_awaitable(thing)
+
+
+def is_async_func(func):
+    if inspect.iscoroutinefunction(func):
+        return True
+    if inspect.isgeneratorfunction(func):
+        return True
+    if inspect.isasyncgenfunction(func):
+        return True
+    return False
+
+
+def is_awaitable(thing):
+    if inspect.iscoroutine(thing):
+        return True
+    if inspect.isawaitable(thing):
+        return True
+    if inspect.isasyncgen(thing):
+        return True
+    return False

--- a/pyblazing/connector/utils.py
+++ b/pyblazing/connector/utils.py
@@ -1,6 +1,7 @@
 import inspect
 from blazingdb.protocol import Client, AsyncClient, UnixSocketConnection
 
+
 def bind_request(create_request, handle_response):
 
     def do_request(self, *args, **kwargs):
@@ -20,7 +21,7 @@ def bind_request(create_request, handle_response):
         return result
 
     def request(self, *args, **kwargs):
-        if is_caller_async():
+        if self.asyncio_enabled and is_caller_async():
             return handle_response_async(self, do_request_async(self, *args, **kwargs))
         return handle_response(self, do_request(self, *args, **kwargs))
 


### PR DESCRIPTION
* Splits the `PyConnector` methods into request/response handlers
* Adds a wrapper for each `PyConnector` method that checks whether it's being called from an async function
* Implement just enough functions to make `run_query` work both sync and async:

```python
def run_query_sync(*args, **kwargs):
    return pyblazing.run_query(*args, **kwargs)

async def run_query_async(*args, **kwargs):
    return await pyblazing.run_query(*args, **kwargs)

sync_handle = run_query_sync('SELECT * FROM main.df', {'df': df})
print(sync_handle.columns)

async_handle = await run_query_async('SELECT * FROM main.df', {'df': df})
print(async_handle.columns)
```

cc: @aucahuasi