### PR TITLE
[REVIEW] Use cudf.set_allocator to initialize GPU memory allocator

### DIFF
--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -114,6 +114,12 @@ def initializeBlazing(ralId=0, networkInterface='lo', singleNode=False):
     ralCommunicationPort = random.randint(10000, 32000) + ralId
     while checkSocket(ralCommunicationPort) == False:
         ralCommunicationPort = random.randint(10000, 32000) + ralId
+
+    cudf.set_allocator(allocator="managed",
+                        pool=True,
+                        initial_pool_size=None,# Default is 1/2 total GPU memory
+                        enable_logging=False)
+
     cio.initializeCaller(
         ralId,
         0,


### PR DESCRIPTION
`cudf.set_allocator` calls `rmm.reinitialize`. It's just a wrapper that guarantees the function is called exactly once.