### PR TITLE
[WIP] Conda: removing Cuda labels

### DIFF
--- a/ci/cpu/upload_anaconda.sh
+++ b/ci/cpu/upload_anaconda.sh
@@ -4,7 +4,7 @@ set -e
 
 export TAR_FILE=`conda build conda/recipes/blazingsql/ --python=$PYTHON --output`
 
-LABEL_OPTION="--label main --label cuda"$CUDA_VER
+LABEL_OPTION="--label main"
 echo "LABEL_OPTION=${LABEL_OPTION}"
 
 if [ -z "$MY_UPLOAD_KEY" ]; then

--- a/conda/recipes/blazingsql/meta.yaml
+++ b/conda/recipes/blazingsql/meta.yaml
@@ -11,7 +11,7 @@ package:
 
 build:
     number: {{ git_revision_count }}
-    string: cuda{{ cuda_version + '_py' + py_version + '_' + git_revision_count }}
+    string: py{{ py_version }}_{{ git_revision_count }}
     script_env:
       - CUDA_VERSION
       - CUDACXX
@@ -55,7 +55,6 @@ requirements:
         - arrow-cpp=0.15.0
         - bsql-toolchain {{ version }}.*
         - cppzmq
-        - cudatoolkit {{ cuda_version }}.*
         - librmm {{ rapids_build_version }}.*
         - libnvstrings {{ rapids_build_version }}.*
         - libcudf {{ rapids_build_version }}.*


### PR DESCRIPTION
We will don't need to use Cuda labels. So, the command to install BlazingSQL will be:
```
conda install -c blazingsql -c rapidsai -c conda-forge -c defaults blazingsql cudatoolkit=10.0 python=3.7
```
But, we must change cudatoolkit and python versions.