### PR TITLE
[REVIEW] updated code due to cudf changed API for hash_partition function

### DIFF
--- a/engine/src/execution_graph/logic_controllers/LogicalFilter.h
+++ b/engine/src/execution_graph/logic_controllers/LogicalFilter.h
@@ -28,12 +28,6 @@ std::unique_ptr<ral::frame::BlazingTable> process_filter(
   const std::string & query_part,
   blazingdb::manager::experimental::Context * context);
 
-std::vector<std::unique_ptr<ral::frame::BlazingTable> > hashPartition(
-    const ral::frame::BlazingTableView & table,
-    std::vector<cudf::size_type> const& columns_to_hash,
-    int numPartitions);
-
-
 
 
 std::unique_ptr<ral::frame::BlazingTable> evaluateExpression(


### PR DESCRIPTION
The new hash_partition function has the following API 
```std::pair<std::unique_ptr<experimental::table>, std::vector<size_type>>
hash_partition(table_view const& input,
               std::vector<size_type> const& columns_to_hash,
               int num_partitions,
               rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());```

Which means we want to use split with the output, which in turn means that the way the allocations need to be managed changed a bit, which resulted in refactoring a bit of the code 