### PR TITLE
[REVIEW] Fix create empty tables: when there are no selected indices read all the schema

### DIFF
--- a/engine/src/io/DataLoader.cpp
+++ b/engine/src/io/DataLoader.cpp
@@ -132,9 +132,14 @@ ral::frame::TableViewPair data_loader::load_data(
 		if (if_null_empty_load) {
 			std::vector<std::string> select_names(column_indices.size());
 			std::vector<cudf::type_id> select_types(column_indices.size());
-			for (int i = 0; i < column_indices.size(); i++){
-				select_names[i] = schema.get_names()[column_indices[i]];
-				select_types[i] = schema.get_dtypes()[column_indices[i]];
+			if (column_indices.empty()) {
+				select_types = schema.get_dtypes();
+				select_names = schema.get_names();
+			} else {
+				for (int i = 0; i < column_indices.size(); i++){
+					select_names[i] = schema.get_names()[column_indices[i]];
+					select_types[i] = schema.get_dtypes()[column_indices[i]];
+				}
 			}
 
 			ds = ral::frame::createEmptyTableViewPair(select_types, select_names);


### PR DESCRIPTION
Fix cases when we want to read a single file using many dask workers and we are not selecting any index (e.g. select * ...)