### PR TITLE
[REVIEW] Parquet workaround for reading consecutive rowgroups

### DIFF
--- a/engine/src/io/data_parser/ParquetParser.cpp
+++ b/engine/src/io/data_parser/ParquetParser.cpp
@@ -97,8 +97,10 @@ std::unique_ptr<ral::frame::BlazingTable> parquet_parser::parse(
 			consecutive_row_group_length.push_back(length_count);
 
 			if (consecutive_row_group_start.size() == 1){
-				pq_args.row_group = consecutive_row_group_start[0];
-				pq_args.row_group_count = consecutive_row_group_length[0];
+				// Uncomment this code when the consecutive rowgroups issue is fixed
+				// https://github.com/rapidsai/cudf/pull/4591
+				// pq_args.row_group = consecutive_row_group_start[0];
+				// pq_args.row_group_count = consecutive_row_group_length[0];
 
 				auto result = cudf_io::read_parquet(pq_args);
 				return std::make_unique<ral::frame::BlazingTable>(std::move(result.tbl), result.metadata.column_names);				

--- a/engine/src/utilities/CommonOperations.cpp
+++ b/engine/src/utilities/CommonOperations.cpp
@@ -7,6 +7,7 @@
 #include "cudf/null_mask.hpp"
 #include "cudf/types.hpp"
 #include <cudf/filling.hpp>
+#include <cudf/concatenate.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <algorithm>
 #include <blazingdb/io/Library/Logging/Logger.h>


### PR DESCRIPTION
This is a temporary workaround that fixes #463 