### PR TITLE
[Testing] made us have same behaviour as cudf for reading csv (header)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 #391 Added the ability to run count distinct queries in a distruted fashion
 #392 Remove the unnecessary messages on distributed mode
 #560 Fixed bug where parsing errors would lead to crash
+#565 made us have same behaviour as cudf for reading csv

--- a/engine/src/io/data_parser/ArgsUtil.cpp
+++ b/engine/src/io/data_parser/ArgsUtil.cpp
@@ -147,10 +147,9 @@ void getReaderArgCSV(std::map<std::string, std::string> args, ReaderArgs & reade
 	if(in("skipfooter", args)) {
 		readerArg.csvReaderArg.skipfooter = (cudf::size_type) to_int(args["skipfooter"]);
 	}
-	if(in("header", args)) {
+	if(in("header", args) && args["header"] != "None" ) {
 		readerArg.csvReaderArg.header = (cudf::size_type) to_int(args["header"]);
-	} else {
-		// NOTE check this default value percy c.cordova
+	} else if(args["header"] == "None"){
 		readerArg.csvReaderArg.header = -1;
 	}
 	if(in("names", args)) {


### PR DESCRIPTION
Before this we were defaulting to header=-1 and not handling header=None. This now handles both those situations in the same way that read_csv does.