### PR TITLE
Fix error on copy construction address

### DIFF
--- a/comms/src/blazingdb/transport/Address.cc
+++ b/comms/src/blazingdb/transport/Address.cc
@@ -11,7 +11,9 @@ namespace experimental {
 Address::Address(){}
  
 Address::Address(const Address& address){
-  this->metadata_ = address.metadata_;
+  this->metadata_.type = address.metadata_.type;
+  this->metadata_.comunication_port = address.metadata_.comunication_port;
+  this->metadata_.protocol_port = address.metadata_.protocol_port;
   memcpy(this->metadata_.ip, address.metadata_.ip, ADDRSTRLEN);
 }
 


### PR DESCRIPTION
Before we were copying metadata and this is incorrect because metadata has a static array inside of it. This properly handles the copying of the metadata. We should in the future modify metadat so that it uses std::string instead