### PR TITLE
[Testing] added changes to be able to run a query on a single gpu via dask and …

### DIFF
--- a/comms/src/blazingdb/transport/Address.cc
+++ b/comms/src/blazingdb/transport/Address.cc
@@ -9,9 +9,12 @@ namespace transport {
 namespace experimental {
 
 Address::Address(){}
- 
+
 Address::Address(const Address& address){
-  this->metadata_ = address.metadata_;
+
+  this->metadata_.type = address.metadata_.type;
+  this->metadata_.comunication_port = address.metadata_.comunication_port;
+  this->metadata_.protocol_port = address.metadata_.protocol_port;
   memcpy(this->metadata_.ip, address.metadata_.ip, ADDRSTRLEN);
 }
 

--- a/engine/bsql_engine/io/io.pyx
+++ b/engine/bsql_engine/io/io.pyx
@@ -161,11 +161,11 @@ cpdef parseSchemaCaller(fileList, file_format_hint, args, extra_columns, ignore_
 
     cdef vector[pair[string,type_id]] extra_columns_cpp
     cdef pair[string,type_id] extra_column_cpp
-    
+
     for extra_column in extra_columns:
         extra_column_cpp = (extra_column[0].encode(),extra_column[1])
         extra_columns_cpp.push_back(extra_column_cpp)
-                
+
     tableSchema = parseSchemaPython(files,str.encode(file_format_hint),arg_keys,arg_values, extra_columns_cpp, ignore_missing_paths)
     return_object = {}
     return_object['datasource'] = files
@@ -175,7 +175,7 @@ cpdef parseSchemaCaller(fileList, file_format_hint, args, extra_columns, ignore_
     return_object['types'] = tableSchema.types
     return_object['names'] = tableSchema.names
     return_object['calcite_to_file_indices']= tableSchema.calcite_to_file_indices
-    
+
     return return_object
 
 
@@ -206,7 +206,7 @@ cpdef parseMetadataCaller(fileList, offset, schema, file_format_hint, args):
         decoded_names.append(names[i].decode('utf-8'))
 
     df = cudf.DataFrame(CudfXxTable.from_unique_ptr(blaz_move(dereference(resultSet).cudfTable), decoded_names)._data)
-    df._rename_columns(decoded_names)    
+    df._rename_columns(decoded_names)
     return df
 
 cpdef performPartitionCaller(int masterIndex, tcpMetadata, int ctxToken, input, by):
@@ -242,11 +242,12 @@ cpdef performPartitionCaller(int masterIndex, tcpMetadata, int ctxToken, input, 
         decoded_names.append(names[i].decode('utf-8'))
 
     df = cudf.DataFrame(CudfXxTable.from_unique_ptr(blaz_move(dereference(resultSet).cudfTable), decoded_names)._data)
-    
+
     return df
 
 cpdef runQueryCaller(int masterIndex,  tcpMetadata,  tables,  vector[int] fileTypes, int ctxToken, queryPy, unsigned long accessToken, bool use_execution_graph):
     cdef string query
+
     query = str.encode(queryPy)
     cdef vector[NodeMetaDataTCP] tcpMetadataCpp
     cdef vector[TableSchema] tableSchemaCpp
@@ -278,11 +279,11 @@ cpdef runQueryCaller(int masterIndex,  tcpMetadata,  tables,  vector[int] fileTy
           key = column_tuple[0]
           value = column_tuple[1]
           cur_uri_values[key.encode()] = value.encode()
-          
+
         uri_values_cpp.push_back(cur_uri_values)
-        
+
       uri_values_cpp_all.push_back(uri_values_cpp)
-      
+
       tableNames.push_back(str.encode(tableName))
       table = tables[tableName]
       currentFilesAll.resize(0)
@@ -293,8 +294,8 @@ cpdef runQueryCaller(int masterIndex,  tcpMetadata,  tables,  vector[int] fileTy
       types.resize(0)
       names.resize(0)
       fileType = fileTypes[tableIndex]
-      
-      if len(table.file_column_names) == 0:      
+
+      if len(table.file_column_names) == 0:
         for col_name in table.column_names:
           if type(col_name) == np.str:
               names.push_back(col_name.encode())
@@ -343,7 +344,7 @@ cpdef runQueryCaller(int masterIndex,  tcpMetadata,  tables,  vector[int] fileTy
         currentMetadataCpp.ip = currentMetadata['ip'].encode()
         currentMetadataCpp.communication_port = currentMetadata['communication_port']
         tcpMetadataCpp.push_back(currentMetadataCpp)
-
+    
     resultSet = blaz_move(runQueryPython(masterIndex, tcpMetadataCpp, tableNames, tableSchemaCpp, tableSchemaCppArgKeys, tableSchemaCppArgValues, filesAll, fileTypes, ctxToken, query,accessToken,uri_values_cpp_all, use_execution_graph))
 
     names = dereference(resultSet).names
@@ -352,7 +353,7 @@ cpdef runQueryCaller(int masterIndex,  tcpMetadata,  tables,  vector[int] fileTy
         decoded_names.append(names[i].decode('utf-8'))
 
     df = cudf.DataFrame(CudfXxTable.from_unique_ptr(blaz_move(dereference(resultSet).cudfTable), decoded_names)._data)
-    
+
     return df
 
 
@@ -365,13 +366,13 @@ cpdef runSkipDataCaller(table, queryPy):
 
     query = str.encode(queryPy)
     all_column_names.resize(0)
-    
+
     for col_name in table.column_names:
       if type(col_name) == np.str:
         all_column_names.push_back(col_name.encode())
       else: # from file
         all_column_names.push_back(col_name)
-    
+
     column_views.resize(0)
     metadata_col_names = [name.encode() for name in table.metadata._data.keys()]
     for cython_col in table.metadata._data.values():
@@ -392,7 +393,7 @@ cpdef runSkipDataCaller(table, queryPy):
           decoded_names.append(names[i].decode('utf-8'))
 
       df = cudf.DataFrame(CudfXxTable.from_unique_ptr(blaz_move(dereference(resultSet).cudfTable), decoded_names)._data)
-      return_object['metadata'] = df 
+      return_object['metadata'] = df
       return return_object
 
 cpdef getTableScanInfoCaller(logicalPlan,tables):

--- a/engine/src/cython/engine.cpp
+++ b/engine/src/cython/engine.cpp
@@ -31,7 +31,7 @@ std::pair<std::vector<ral::io::data_loader>, std::vector<ral::io::Schema>> get_l
 		auto tableSchema = tableSchemas[i];
 		auto files = filesAll[i];
 		auto fileType = fileTypes[i];
-		
+
 		auto kwargs = ral::io::to_map(tableSchemaCppArgKeys[i], tableSchemaCppArgValues[i]);
 		ral::io::ReaderArgs args = ral::io::getReaderArgs((ral::io::DataType) fileType, kwargs);
 
@@ -122,7 +122,7 @@ std::unique_ptr<ResultSet> runQuery(int32_t masterIndex,
 		} else {
 			frame = evaluate_query(input_loaders, schemas, tableNames, query, accessToken, queryContext);
 		}
-		
+
 		std::unique_ptr<ResultSet> result = std::make_unique<ResultSet>();
 		result->names = frame->names();
 		result->cudfTable = frame->releaseCudfTable();
@@ -183,11 +183,11 @@ std::unique_ptr<ResultSet> performPartition(int32_t masterIndex,
 }
 
 
-std::unique_ptr<ResultSet> runSkipData(ral::frame::BlazingTableView metadata, 
+std::unique_ptr<ResultSet> runSkipData(ral::frame::BlazingTableView metadata,
 	std::vector<std::string> all_column_names, std::string query) {
 
 	try {
-	
+
 		std::pair<std::unique_ptr<ral::frame::BlazingTable>, bool> result_pair = ral::skip_data::process_skipdata_for_table(
 				metadata, all_column_names, query);
 

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -1558,7 +1558,7 @@ class BlazingContext(object):
             if(ftype == DataType.PARQUET or ftype == DataType.ORC or ftype == DataType.JSON or ftype == DataType.CSV):
                 if new_tables[table].has_metadata():
                     scan_table_query = relational_algebra_steps[table]['table_scans'][0]
-                    currentTableNodes = self._optimize_with_skip_data_getSlices(new_tables[table], scan_table_query)
+                    currentTableNodes = self._optimize_with_skip_data_getSlices(new_tables[table], scan_table_query,single_gpu)
                 else:
                     if single_gpu == True:
                         currentTableNodes = new_tables[table].getSlices(1)

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -1312,37 +1312,18 @@ class BlazingContext(object):
 
 
     def _optimize_with_skip_data_getSlices(self, current_table, scan_table_query,single_gpu=False):
-        print("_optimize_with_skip_data_getSlices start")
-        print("column_names: ")
-        print(current_table.column_names)
-        print("files: ")
-        print(current_table.files)
-        print("metadata: ")
-        print(current_table.metadata)
-        print("uri_values: ")
-        print(current_table.uri_values)
-                
-        print("scan_table_query")
-        print(scan_table_query)
-
+        
         nodeFilesList = []
         file_indices_and_rowgroup_indices = cio.runSkipDataCaller(current_table, scan_table_query)
         skipdata_analysis_fail = file_indices_and_rowgroup_indices['skipdata_analysis_fail']
         file_indices_and_rowgroup_indices = file_indices_and_rowgroup_indices['metadata']
 
-        print("skipdata_analysis_fail")
-        print(skipdata_analysis_fail)
-        print("file_indices_and_rowgroup_indices")
-        print(file_indices_and_rowgroup_indices)
-
         if not skipdata_analysis_fail:
-            print("not skipdata_analysis_fail start")
             actual_files = []
             uri_values = []
             row_groups_ids = []
 
             if not file_indices_and_rowgroup_indices.empty: #skipdata did not filter everything
-                print("not file_indices_and_rowgroup_indices.empty start")
 
                 file_and_rowgroup_indices = file_indices_and_rowgroup_indices.to_pandas()
                 files = file_and_rowgroup_indices['file_handle_index'].values.tolist()
@@ -1357,14 +1338,7 @@ class BlazingContext(object):
                     row_groups_ids.append(row_group_ids)
 
             if self.dask_client is None:
-                print("self.dask_client is None start")
-                print("row_groups_ids")
-                print(row_groups_ids)
-                print("actual_files")
-                print(actual_files)
-                print("uri_values")
-                print(uri_values)
-
+                
                 bt = BlazingTable(current_table.input,
                                 current_table.fileType,
                                 files=actual_files,
@@ -1379,22 +1353,10 @@ class BlazingContext(object):
                 nodeFilesList.append(bt)
 
             else:
-                print("else NOT self.dask_client is None start")
-                print("row_groups_ids")
-                print(row_groups_ids)
                 if single_gpu:
-                    print("single_gpu start")
-
+                
                     all_sliced_files, all_sliced_uri_values, all_sliced_row_groups_ids = self._sliceRowGroups(1, actual_files, uri_values, row_groups_ids)
                     i = 0
-
-                    print("all_sliced_files[" + str(i) + "]")
-                    print(all_sliced_files[i])
-                    print("all_sliced_uri_values[" + str(i) + "]")
-                    print(all_sliced_uri_values[i])
-                    print("all_sliced_row_groups_ids[" + str(i) + "]")
-                    print(all_sliced_row_groups_ids[i])
-                    
 
                     bt = BlazingTable(current_table.input,
                                 current_table.fileType,
@@ -1409,18 +1371,10 @@ class BlazingContext(object):
                     bt.column_types = current_table.column_types
                     nodeFilesList.append(bt)
                 else:
-                    print("not single_gpu start")
 
                     all_sliced_files, all_sliced_uri_values, all_sliced_row_groups_ids = self._sliceRowGroups(len(self.nodes), actual_files, uri_values, row_groups_ids)
 
                     for i, node in enumerate(self.nodes):
-                        print("all_sliced_files[" + str(i) + "]")
-                        print(all_sliced_files[i])
-                        print("all_sliced_uri_values[" + str(i) + "]")
-                        print(all_sliced_uri_values[i])
-                        print("all_sliced_row_groups_ids[" + str(i) + "]")
-                        print(all_sliced_row_groups_ids[i])
-
                         bt = BlazingTable(current_table.input,
                                     current_table.fileType,
                                     files=all_sliced_files[i],
@@ -1435,8 +1389,6 @@ class BlazingContext(object):
                         nodeFilesList.append(bt)
             return nodeFilesList
         else:
-            print("skipdata_analysis_fail start")
-
             if single_gpu:
                 return current_table.getSlices(1)
             else:
@@ -1637,9 +1589,7 @@ class BlazingContext(object):
 
             for j, nodeList in enumerate(nodeTableList):
                 nodeList[table] = currentTableNodes[j]
-                print("Table: " + table + " node " + str(j))
-                print(nodeList[table].files)
-
+                
         ctxToken = random.randint(0, 64000)
         accessToken = 0
         if (len(table_list) > 0):


### PR DESCRIPTION
…also to return a future instead of the materialized result set

resolves https://github.com/BlazingDB/blazingsql/issues/566

Basically what this pr does is add two parameters to .sql()

single_gpu = True|False (default False)
This allows the user to specify that the query in question will be run on a single gpu. Can be useful if a user has prepartitioned tables and wants to line them up to avoid shuffles during join.

return_futures = True|False (default False)
This allows the user to specify that instead of a dask dataframe they want to get a future to be able to get that dataframe later on. Makes .sql return almost instantly since now the query is happening asynchronously