### PR TITLE
[TESTING] Avoid the use of the engine when the optimized plan contains a LogicalValues

### DIFF
--- a/algebra/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/RelationalAlgebraGenerator.java
+++ b/algebra/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/RelationalAlgebraGenerator.java
@@ -256,4 +256,49 @@ public class RelationalAlgebraGenerator {
 
 		return response;
 	}
+	
+	/**
+	 * Takes a sql statement and converts it into an Non-optimized relational algebra
+	 * node.
+	 *
+	 * @param sql a string sql query that is to be parsed and converted into
+	 *     relational algebra
+	 * @return a RelNode which contains the relational algebra tree generated from
+	 *     the sql statement provided 
+	 * @throws SqlSyntaxException, SqlValidationException, RelConversionException
+	 */
+	public RelNode
+	getRelationalAlgebraNonOptimized(String sql) throws SqlSyntaxException, SqlValidationException, RelConversionException {
+		RelNode nonOptimizedPlan = getNonOptimizedRelationalAlgebra(sql);
+		LOGGER.debug("non optimized\n" + RelOptUtil.toString(nonOptimizedPlan));
+
+		return nonOptimizedPlan;
+	}
+	
+	public String
+	getRelationalAlgebraNonOptimizedString(String sql) throws SqlSyntaxException, SqlValidationException, RelConversionException {
+		String response = "";
+
+		try {
+			response = RelOptUtil.toString(getRelationalAlgebraNonOptimized(sql));
+		}catch(SqlValidationException ex){
+			//System.out.println(ex.getMessage());
+			//System.out.println("Found validation err!");
+			return "fail: \n " + ex.getMessage();
+		}catch(SqlSyntaxException ex){
+			//System.out.println(ex.getMessage());
+			//System.out.println("Found syntax err!");
+			return "fail: \n " + ex.getMessage();
+		} catch(Exception ex) {
+			//System.out.println(ex.toString());
+			//System.out.println(ex.getMessage());
+			ex.printStackTrace();
+
+			LOGGER.error(ex.getMessage());
+			return "fail: \n " + ex.getMessage();
+		}
+
+		return response;
+	}
+	
 }

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -1024,6 +1024,7 @@ class BlazingContext(object):
         """
         try:
             algebra = str(self.generator.getRelationalAlgebraString(sql))
+            algebraNonOptimized = str(self.generator.getRelationalAlgebraNonOptimizedString(sql))
         except jpype.JException as exception:
             algebra = ""
             print("SQL Parsing Error")
@@ -1032,6 +1033,11 @@ class BlazingContext(object):
             print("Error found")
             print(algebra)
             algebra=""
+
+        # When there is neither TableScan nor BindableTableScan nor Project and we still need the schema. An empty table will be returned
+        if algebra.find("LogicalValues(tuples=[[]])"):
+            algebra = algebraNonOptimized
+
         return algebra
 
     def add_remove_table(self, tableName, addTable, table=None):

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -1035,7 +1035,7 @@ class BlazingContext(object):
             algebra=""
 
         # When there is neither TableScan nor BindableTableScan nor Project and we still need the schema. An empty table will be returned
-        if algebra.find("LogicalValues(tuples=[[]])"):
+        if algebra.find("LogicalValues(tuples=[[]])") or algebra.rstrip() == "LogicalValues(tuples=[[]])":
             algebra = algebraNonOptimized
 
         return algebra


### PR DESCRIPTION
Closes #429 
Simple case:

`query_ = "select n_nationkey FROM nation WHERE n_nationkey BETWEEN 5 AND 1"`

Then the logical plans are:
```
DEBUG: com.blazingdb.calcite.application.RelationalAlgebraGenerator - optimized
LogicalValues(tuples=[[]])

DEBUG: com.blazingdb.calcite.application.RelationalAlgebraGenerator - non optimized
LogicalProject(n_nationkey=[$0])
  LogicalFilter(condition=[AND(>=($0, 5), <=($0, 1))])
    LogicalTableScan(table=[[main, nation]])
```