### PR TITLE
feat(gpuci) updating script to build locally

### DIFF
--- a/ci/cpu/upload_anaconda.sh
+++ b/ci/cpu/upload_anaconda.sh
@@ -19,9 +19,12 @@ fi
 
 if [ "$UPLOAD_BLAZING" == "1" ]; then
     LABEL_OPTION="--label main --label cuda"$CUDA
+    if [ ! -z "$CUSTOM_LABEL" ]; then
+      LABEL_OPTION="--label "$CUSTOM_LABEL
+    fi
     echo "LABEL_OPTION=${LABEL_OPTION}"
 
     test -e ${BLAZINGSQL_FILE}
-    echo "Upload blazingsql: "${BLAZINGSQL_FILE}
+    echo "Upload BlazingSQL: "${BLAZINGSQL_FILE}
     anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME} ${LABEL_OPTION} --force ${BLAZINGSQL_FILE}
 fi

--- a/conda-build-docker.sh
+++ b/conda-build-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# usage:   ./conda-build-docker.sh cuda_version python_version conda_upload token
-# example: ./conda-build-docker.sh 9.2|10.0|10.1 3.6|3.7 blazingsql-nightly 123
+# usage:   ./conda-build-docker.sh cuda_version python_version token conda_upload
+# example: ./conda-build-docker.sh 9.2|10.0|10.1 3.6|3.7 123 blazingsql-nightly
 
 export WORKSPACE=$PWD
 
@@ -14,14 +14,20 @@ if [ ! -z $2 ]; then
   PYTHON_VERSION=$2
 fi
 
+CONDA_UPLOAD="blazingsql-nightly"
+if [ ! -z $4 ]; then
+  CONDA_UPLOAD=$4
+fi
+
 docker run --rm -ti \
     --runtime=nvidia \
     -u $(id -u):$(id -g) \
     -e CUDA_VER=${CUDA_VERSION} -e PYTHON=$PYTHON_VERSION \
-    -e CONDA_UPLOAD=$3 -e MY_UPLOAD_KEY=$4 \
+    -e CONDA_UPLOAD=$CONDA_UPLOAD -e MY_UPLOAD_KEY=$3 \
+    -e UPLOAD_BLAZING=1 -e GIT_BRANCH="master" -e SOURCE_BRANCH="master" \
     -e WORKSPACE=$WORKSPACE \
     -v /etc/passwd:/etc/passwd \
     -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} \
-    gpuci/rapidsai-base:cuda${CUDA_VERSION}-centos7-gcc7-py${PYTHON_VERSION} \
-    ./ci/gpu/build.sh
+    gpuci/rapidsai-base:cuda${CUDA_VERSION}-ubuntu16.04-gcc5-py${PYTHON_VERSION} \
+    ./ci/cpu/build.sh
 

--- a/conda-build-docker.sh
+++ b/conda-build-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# usage:   ./conda-build-docker.sh cuda_version python_version token conda_upload
-# example: ./conda-build-docker.sh 9.2|10.0|10.1 3.6|3.7 123 blazingsql-nightly
+# usage:   ./conda-build-docker.sh cuda_version python_version token custom_label conda_account
+# example: ./conda-build-docker.sh 10.0|10.2 3.6|3.7 123 beta blazingsql-nightly
 
 export WORKSPACE=$PWD
 
@@ -14,17 +14,30 @@ if [ ! -z $2 ]; then
   PYTHON_VERSION=$2
 fi
 
-CONDA_UPLOAD="blazingsql-nightly"
+MY_UPLOAD_KEY=""
+UPLOAD_BLAZING="0"
+if [ ! -z $3 ]; then
+  MY_UPLOAD_KEY=$3
+  UPLOAD_BLAZING=1
+fi
+
+CUSTOM_LABEL=""
 if [ ! -z $4 ]; then
-  CONDA_UPLOAD=$4
+  CUSTOM_LABEL=$4
+fi
+
+CONDA_USERNAME="blazingsql-nightly"
+if [ ! -z $5 ]; then
+  CONDA_USERNAME=$5
 fi
 
 docker run --rm -ti \
     --runtime=nvidia \
     -u $(id -u):$(id -g) \
     -e CUDA_VER=${CUDA_VERSION} -e PYTHON=$PYTHON_VERSION \
-    -e CONDA_UPLOAD=$CONDA_UPLOAD -e MY_UPLOAD_KEY=$3 \
-    -e UPLOAD_BLAZING=1 -e GIT_BRANCH="master" -e SOURCE_BRANCH="master" \
+    -e CONDA_USERNAME=$CONDA_USERNAME -e MY_UPLOAD_KEY=$MY_UPLOAD_KEY \
+    -e UPLOAD_BLAZING=$UPLOAD_BLAZING -e CUSTOM_LABEL=$CUSTOM_LABEL \
+    -e GIT_BRANCH="master" -e SOURCE_BRANCH="master" \
     -e WORKSPACE=$WORKSPACE \
     -v /etc/passwd:/etc/passwd \
     -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} \


### PR DESCRIPTION
This fix is to be able to build a Conda package from a local docker container which is emulating gpuCI environment.
Example:
```
$ ./conda-build-docker.sh 10.0 3.7 <conda_token> beta mario21ic-nightly
```