### PR TITLE
[REVIEW] added logging into the initialization

### DIFF
--- a/engine/src/cython/initialize.cpp
+++ b/engine/src/cython/initialize.cpp
@@ -31,6 +31,9 @@
 #include <spdlog/async.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
+using namespace fmt::literals;
+
+#include <engine/static.h> // this contains function call for getProductDetails
 
 std::string get_ip(const std::string & iface_name = "eth0") {
 	int fd;
@@ -96,11 +99,6 @@ void initialize(int ralId,
 		ral::communication::network::Server::getInstance().close();
 	}
 
-	// auto output = new Library::Logging::CoutOutput();
-	// Library::Logging::ServiceLogging::getInstance().setLogOutput(output);
-	// Library::Logging::ServiceLogging::getInstance().setNodeIdentifier(ralId);
-	// Library::Logging::Logger().logTrace(ral::utilities::buildLogString("0","0","0",	initLogMsg));
-
 	// Init AWS S3 ... TODO see if we need to call shutdown and avoid leaks from s3 percy
 	BlazingContext::getInstance()->initExternalSystems();
 
@@ -121,6 +119,17 @@ void initialize(int ralId,
 
 	spdlog::flush_on(spdlog::level::err);
 	spdlog::flush_every(std::chrono::seconds(1));
+
+	logger->debug("|||{info}|||||","info"_a=initLogMsg);
+
+	std::map<std::string, std::string> product_details = getProductDetails();
+	std::string product_details_str = "Product Details: ";
+	std::map<std::string, std::string>::iterator it = product_details.begin(); 
+	while (it != product_details.end())	{
+		product_details_str += it->first + ": " + it->second + "; ";
+		it++;
+	}
+	logger->debug("|||{info}|||||","info"_a=product_details_str);
 }
 
 void finalize() {

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -799,7 +799,9 @@ class BlazingContext(object):
         self.nodes = []
         self.node_cwds = []
         self.finalizeCaller = lambda: NotImplemented
-        self.config_options = config_options
+        self.config_options = {}
+        for option in config_options:
+            self.config_options[option.encode()] = str(config_options[option]).encode() # make sure all options are encoded strings
         
         if(dask_client is not None):
             if network_interface is None:
@@ -1572,11 +1574,11 @@ class BlazingContext(object):
             return
 
         if len(config_options) == 0:
-            config_options = self.config_options 
-        
-        query_config_options = {}
-        for option in config_options:
-            query_config_options[option.encode()] = str(config_options[option]).encode() # make sure all options are encoded strings
+            query_config_options = self.config_options 
+        else:        
+            query_config_options = {}
+            for option in config_options:
+                query_config_options[option.encode()] = str(config_options[option]).encode() # make sure all options are encoded strings
 
         if self.dask_client is None or single_gpu == True :
             new_tables, relational_algebra_steps = cio.getTableScanInfoCaller(algebra,self.tables)


### PR DESCRIPTION
implements logging into the initialization which includes product info and initialization info:

2020-05-15 09:33:02.944|0|debug||||INITIALIZING RAL. RAL ID: 0, RAL Host: 127.0.0.1:18022, Network 
Interface: lo, , Is Not Single Node, CUDA_VISIBLE_DEVICES is set to: 0,1, |||||
2020-05-15 09:33:02.944|0|debug||||Product Details: BLAZINGSQL_GIT_BRANCH: fix/missing_nodes_in_das
k_cudf_table; BLAZINGSQL_GIT_COMMIT_HASH: 32805f63f526b59920c8cc045ce1a98bde062ba6; BLAZINGSQL_GIT_
DESCRIBE_NUMBER: 429; BLAZINGSQL_GIT_DESCRIBE_TAG: v0.14.0; CMAKE_CUDA_COMPILER: /usr/local/cuda/bi
n/nvcc; CMAKE_CUDA_FLAGS: -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -
gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_70,code=compute_70 --expt-extended-lambda 
--expt-relaxed-constexpr -Werror cross-execution-space-call -Wno-deprecated-declarations -Xptxas --
disable-warnings -Werror cross-execution-space-call -Xcompiler -Wall; CMAKE_GENERATOR: Unix Makefil
es; CMAKE_VERSION: 3.14.0; CXX_COMPILER: /usr/bin/c++; CXX_COMPILER_ID: GNU; CXX_COMPILER_VERSION: 
5.4.0; LSB_RELEASE: DISTRIB_ID=Ubuntu|DISTRIB_RELEASE=16.04|DISTRIB_CODENAME=xenial|DISTRIB_DESCRIP
TION=Ubuntu 16.04.5 LTS; OS_RELEASE: NAME=Ubuntu|VERSION=16.04.5 LTS (Xenial Xerus)|ID=ubuntu|ID_LI
KE=debian|PRETTY_NAME=Ubuntu 16.04.5 LTS|VERSION_ID=16.04|HOME_URL=http://www.ubuntu.com/|SUPPORT_U
RL=http://help.ubuntu.com/|BUG_REPORT_URL=http://bugs.launchpad.net/ubuntu/|VERSION_CODENAME=xenial
|UBUNTU_CODENAME=xenial; SYSTEM: Linux-4.4.0-140-generic; SYSTEM_NAME: Linux; SYSTEM_PROCESSOR: x86
_64; |||||
