### PR TITLE
[REVIEW] added guava to pom.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,4 @@
 #653 Handle exceptions on python side
 #661 added hive support to parse_batch
 #662 updated from_cudf code and fixed other issue due to new cudf::list_view
-
+#677 added guava to pom.xml

--- a/algebra/blazingdb-calcite-core/pom.xml
+++ b/algebra/blazingdb-calcite-core/pom.xml
@@ -41,6 +41,12 @@
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>19.0</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/algebra/blazingdb-calcite-core/pom.xml
+++ b/algebra/blazingdb-calcite-core/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>19.0</version>
+			<version>18.0</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
certain queries were having errors like if you tried to do between or a x > a and x < b type of query. it was because of a class missing because of missing guava dependencies