### PR TITLE
Revert "[REVIEW] Fix/vector result tables"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@
 #662 updated from_cudf code and fixed other issue due to new cudf::list_view
 #677 added guava to pom.xml
 #679 Support modern compilers (>= g++-7.x)
+#6449 Adding event logging
 #649 Adding event logging
 #660 Changed how we handle the partitions of a dask.cudf.DataFrame
 #697 Update expression parser
-#601 Adding checkings to detect length overflow when concatenating string columns in dask
 #659 Improve reading for: SELECT * FROM table LIMIT N
 #700 Support null column in projection

--- a/engine/bsql_engine/io/cio.pxd
+++ b/engine/bsql_engine/io/cio.pxd
@@ -57,10 +57,6 @@ cdef extern from "../include/io/io.h":
         vector[string]  names
         bool skipdata_analysis_fail
 
-    cdef struct PartitionedResultSet:
-        vector[unique_ptr[table]] cudfTables
-        vector[string]  names
-        bool skipdata_analysis_fail
 
     ctypedef enum DataType:
         UNDEFINED = 999,
@@ -150,7 +146,7 @@ cdef extern from "../include/engine/engine.h":
         cdef struct NodeMetaDataTCP:
             string ip
             int communication_port
-        unique_ptr[PartitionedResultSet] runQuery(int masterIndex, vector[NodeMetaDataTCP] tcpMetadata, vector[string] tableNames, vector[TableSchema] tableSchemas, vector[vector[string]] tableSchemaCppArgKeys, vector[vector[string]] tableSchemaCppArgValues, vector[vector[string]] filesAll, vector[int] fileTypes, int ctxToken, string query, unsigned long accessToken, vector[vector[map[string,string]]] uri_values_cpp, map[string,string] config_options) except +raiseRunQueryError
+        unique_ptr[ResultSet] runQuery(int masterIndex, vector[NodeMetaDataTCP] tcpMetadata, vector[string] tableNames, vector[TableSchema] tableSchemas, vector[vector[string]] tableSchemaCppArgKeys, vector[vector[string]] tableSchemaCppArgValues, vector[vector[string]] filesAll, vector[int] fileTypes, int ctxToken, string query, unsigned long accessToken, vector[vector[map[string,string]]] uri_values_cpp, map[string,string] config_options) except +raiseRunQueryError
         unique_ptr[ResultSet] runSkipData(BlazingTableView metadata, vector[string] all_column_names, string query) except +raiseRunSkipDataError
 
         cdef struct TableScanInfo:

--- a/engine/bsql_engine/io/io.pyx
+++ b/engine/bsql_engine/io/io.pyx
@@ -103,7 +103,7 @@ cdef cio.TableSchema parseSchemaPython(vector[string] files, string file_format_
 cdef unique_ptr[cio.ResultSet] parseMetadataPython(vector[string] files, pair[int,int] offset, cio.TableSchema schema, string file_format_hint, vector[string] arg_keys, vector[string] arg_values):
     return blaz_move( cio.parseMetadata(files, offset, schema, file_format_hint,arg_keys,arg_values) )
 
-cdef unique_ptr[cio.PartitionedResultSet] runQueryPython(int masterIndex, vector[NodeMetaDataTCP] tcpMetadata, vector[string] tableNames, vector[TableSchema] tableSchemas, vector[vector[string]] tableSchemaCppArgKeys, vector[vector[string]] tableSchemaCppArgValues, vector[vector[string]] filesAll, vector[int] fileTypes, int ctxToken, string query, unsigned long accessToken,vector[vector[map[string,string]]] uri_values_cpp, map[string,string] config_options) except *:
+cdef unique_ptr[cio.ResultSet] runQueryPython(int masterIndex, vector[NodeMetaDataTCP] tcpMetadata, vector[string] tableNames, vector[TableSchema] tableSchemas, vector[vector[string]] tableSchemaCppArgKeys, vector[vector[string]] tableSchemaCppArgValues, vector[vector[string]] filesAll, vector[int] fileTypes, int ctxToken, string query, unsigned long accessToken,vector[vector[map[string,string]]] uri_values_cpp, map[string,string] config_options) except *:
     return blaz_move(cio.runQuery( masterIndex, tcpMetadata, tableNames, tableSchemas, tableSchemaCppArgKeys, tableSchemaCppArgValues, filesAll, fileTypes, ctxToken, query, accessToken, uri_values_cpp, config_options))
 
 cdef unique_ptr[cio.ResultSet] performPartitionPython(int masterIndex, vector[NodeMetaDataTCP] tcpMetadata, int ctxToken, BlazingTableView blazingTableView, vector[string] column_names) except *:
@@ -250,8 +250,7 @@ cpdef parseMetadataCaller(fileList, offset, schema, file_format_hint, args):
         decoded_names.append(names[i].decode('utf-8'))
 
     df = cudf.DataFrame(CudfXxTable.from_unique_ptr(blaz_move(dereference(resultSet).cudfTable), decoded_names)._data)
-    df._rename_columns(decoded_names)
-
+    df._rename_columns(decoded_names)    
     return df
 
 cpdef performPartitionCaller(int masterIndex, tcpMetadata, int ctxToken, input, by):
@@ -287,9 +286,10 @@ cpdef performPartitionCaller(int masterIndex, tcpMetadata, int ctxToken, input, 
         decoded_names.append(names[i].decode('utf-8'))
 
     df = cudf.DataFrame(CudfXxTable.from_unique_ptr(blaz_move(dereference(resultSet).cudfTable), decoded_names)._data)
+    
     return df
 
-cpdef runQueryCaller(int masterIndex,  tcpMetadata,  tables,  vector[int] fileTypes, int ctxToken, queryPy, unsigned long accessToken, map[string,string] config_options, bool is_single_node):
+cpdef runQueryCaller(int masterIndex,  tcpMetadata,  tables,  vector[int] fileTypes, int ctxToken, queryPy, unsigned long accessToken, map[string,string] config_options):
     cdef string query
     query = str.encode(queryPy)
     cdef vector[NodeMetaDataTCP] tcpMetadataCpp
@@ -399,14 +399,9 @@ cpdef runQueryCaller(int masterIndex,  tcpMetadata,  tables,  vector[int] fileTy
     for i in range(names.size()):
         decoded_names.append(names[i].decode('utf-8'))
 
-    if is_single_node: # the engine returns a concatenated dataframe
-      df = cudf.DataFrame(CudfXxTable.from_unique_ptr(blaz_move(dereference(resultSet).cudfTables[0]), decoded_names)._data)
-      return df
-    else: # the engine returns a vector of dataframes
-      dfs = []
-      for i in range(dereference(resultSet).cudfTables.size()):
-        dfs.append(cudf.DataFrame(CudfXxTable.from_unique_ptr(blaz_move(dereference(resultSet).cudfTables[i]), decoded_names)._data))
-      return dfs
+    df = cudf.DataFrame(CudfXxTable.from_unique_ptr(blaz_move(dereference(resultSet).cudfTable), decoded_names)._data)
+    
+    return df
 
 
 cpdef runSkipDataCaller(table, queryPy):
@@ -445,8 +440,7 @@ cpdef runSkipDataCaller(table, queryPy):
           decoded_names.append(names[i].decode('utf-8'))
 
       df = cudf.DataFrame(CudfXxTable.from_unique_ptr(blaz_move(dereference(resultSet).cudfTable), decoded_names)._data)
-      return_object['metadata'] = df
-
+      return_object['metadata'] = df 
       return return_object
 
 cpdef getTableScanInfoCaller(logicalPlan,tables):

--- a/engine/include/engine/engine.h
+++ b/engine/include/engine/engine.h
@@ -16,7 +16,7 @@ struct NodeMetaDataTCP {
 	std::int32_t communication_port;
 };
 
-std::unique_ptr<PartitionedResultSet> runQuery(int32_t masterIndex,
+std::unique_ptr<ResultSet> runQuery(int32_t masterIndex,
 	std::vector<NodeMetaDataTCP> tcpMetadata,
 	std::vector<std::string> tableNames,
 	std::vector<TableSchema> tableSchemas,

--- a/engine/include/io/io.h
+++ b/engine/include/io/io.h
@@ -15,12 +15,6 @@
 typedef ral::io::DataType DataType;
 namespace cudf_io = cudf::io;
 
-struct PartitionedResultSet {
-	std::vector<std::unique_ptr<cudf::table>> cudfTables;
-	std::vector<std::string> names;
-	bool skipdata_analysis_fail;
-};
-
 struct ResultSet {
 	std::unique_ptr<cudf::table> cudfTable;
 	std::vector<std::string> names;

--- a/engine/src/CalciteInterpreter.cpp
+++ b/engine/src/CalciteInterpreter.cpp
@@ -22,7 +22,7 @@
 
 using namespace fmt::literals;
 
-std::vector<std::unique_ptr<ral::frame::BlazingTable>> execute_plan(std::vector<ral::io::data_loader> input_loaders,
+std::unique_ptr<ral::frame::BlazingTable> execute_plan(std::vector<ral::io::data_loader> input_loaders,
 	std::vector<ral::io::Schema> schemas,
 	std::vector<std::string> table_names,
 	std::string logicalPlan,
@@ -35,7 +35,7 @@ std::vector<std::unique_ptr<ral::frame::BlazingTable>> execute_plan(std::vector<
 	try {
 		assert(input_loaders.size() == table_names.size());
 
-		std::vector<std::unique_ptr<ral::frame::BlazingTable>> output_frame;
+		std::unique_ptr<ral::frame::BlazingTable> output_frame;
 		ral::batch::tree_processor tree{
 			.root = {},
 			.context = queryContext.clone(),
@@ -92,8 +92,7 @@ std::vector<std::unique_ptr<ral::frame::BlazingTable>> execute_plan(std::vector<
 
 		if (query_graph->num_nodes() > 0) {
 			ral::cache::cache_settings cache_machine_config;
-			
-			cache_machine_config.type = queryContext.getTotalNodes() <= 1 ? ral::cache::CacheType::CONCATENATING : ral::cache::CacheType::SIMPLE;
+			cache_machine_config.type = ral::cache::CacheType::CONCATENATING;
 			cache_machine_config.context = queryContext.clone();
 
 			*query_graph += link(query_graph->get_last_kernel(), output, cache_machine_config);
@@ -113,7 +112,7 @@ std::vector<std::unique_ptr<ral::frame::BlazingTable>> execute_plan(std::vector<
 									"info"_a="Query Execution Done",
 									"duration"_a=blazing_timer.elapsed_time());
 
-		assert(!output_frame.empty());
+		assert(output_frame != nullptr);
 
 		logger->flush();
 

--- a/engine/src/CalciteInterpreter.h
+++ b/engine/src/CalciteInterpreter.h
@@ -15,7 +15,7 @@
 #include <blazingdb/manager/Context.h>
 using blazingdb::manager::Context;
 
-std::vector<std::unique_ptr<ral::frame::BlazingTable>> execute_plan(std::vector<ral::io::data_loader> input_loaders,
+std::unique_ptr<ral::frame::BlazingTable> execute_plan(std::vector<ral::io::data_loader> input_loaders,
 	std::vector<ral::io::Schema> schemas,
 	std::vector<std::string> table_names,
 	std::string logicalPlan,


### PR DESCRIPTION
Reverts BlazingDB/blazingsql#601

That PR has some good functions related to string length and concatenation that we want to keep, but the way we were handling the multi partition outputs is not quite right on the dask/python side