### PR TITLE
[WIP] Just to track q10 benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 
 ## Bug Fixes
-
+#999 Track q10 - benchmark
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 
 ## Bug Fixes
-#999 Track q10 - benchmark
+#776 Track q10 - benchmark
 
 
 


### PR DESCRIPTION
This PR is to track q10 benchmark on  https://github.com/rapidsai/tpcx-bb-internal/pull/662
and also fix the issue about
`Q10 triage error: org.apache.calcite.runtime.CalciteContextException: From line 7, column 97 to line 7, column 110: Column 'sentiment_word' not found in any table`
Once rapids team merge it, then we should close #760 
