### PR TITLE
[WIP] Just to track q08 benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 #781 Fixed issue with Hive partitions when doing SELECT *
 #754 Normalize columns before distribution in JoinPartitionKernel
 #782 fixed issue with hive partitions base folder
-
+#999 Track q08 - benchamark
 
 # BlazingSQL 0.14.0 (June 9, 2020)
 


### PR DESCRIPTION
This PR is to track q08 benchmark on https://github.com/rapidsai/tpcx-bb-internal/pull/666  and also fix the issue  about:  
`Q08 Triage dask-cudf part of q08 (some categorical error)`

Once rapids team merge it, then we should close #759 