### PR TITLE
[Review] unary ops on literals, added rand() function to interops and parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - #784 Updated set of TPCH queries on the E2E tests
 - #877 round robing dask workers on single gpu queries
 - #880 reraising query errors in context.py
+- #883 add rand() and running unary operations on literals
 
 ## Bug Fixes
 - #774 fixed build issues with latest cudf 0.15 including updating from_cudf

--- a/engine/src/Interpreter/interpreter_cpp.h
+++ b/engine/src/Interpreter/interpreter_cpp.h
@@ -45,6 +45,7 @@ void perform_interpreter_operation(cudf::mutable_table_view & out_table,
 	const std::vector<column_index_type> & final_output_positions,
 	const std::vector<operator_type> & operators,
 	const std::vector<std::unique_ptr<cudf::scalar>> & left_scalars,
-	const std::vector<std::unique_ptr<cudf::scalar>> & right_scalars);
+	const std::vector<std::unique_ptr<cudf::scalar>> & right_scalars,
+	cudf::size_type operation_num_rows = 0);
 
 } // namespace interops

--- a/engine/src/Interpreter/interpreter_cpp.h
+++ b/engine/src/Interpreter/interpreter_cpp.h
@@ -21,7 +21,9 @@ typedef int16_t column_index_type;
 enum column_index : column_index_type {
 	UNARY_INDEX = -1,
 	SCALAR_INDEX = -2,
-	SCALAR_NULL_INDEX = -3
+	SCALAR_NULL_INDEX = -3,
+	NULLARY_INDEX = -4
+
 };
 
 void add_expression_to_interpreter_plan(const ral::parser::parse_tree & expr_tree,

--- a/engine/src/Interpreter/interpreter_ops.cuh
+++ b/engine/src/Interpreter/interpreter_ops.cuh
@@ -17,10 +17,13 @@
 #include <simt/chrono>
 #include <type_traits>
 
+#include <curand_kernel.h>
+
 #include "interpreter_cpp.h"
 #include "error.hpp"
 
 namespace interops {
+
 
 typedef int64_t temp_gdf_valid_type;  // until its an int32 in cudf
 typedef int16_t column_index_type;
@@ -39,6 +42,17 @@ template <>
 CUDA_DEVICE_CALLABLE double getMagicNumber<double>() {
 	return 1.7976931348623123e+308;
 }
+
+__global__ void setup_rand_kernel(curandState *state, unsigned long long seed )
+{
+    int id = threadIdx.x + blockIdx.x * blockDim.x;
+    /* Each thread gets same seed, a different sequence
+       number, no offset */
+    curand_init(seed, id, 0, &state[id]);
+}
+
+
+
 
 using cudf::datetime::detail::datetime_component;
 template <typename Timestamp, datetime_component Component>
@@ -158,7 +172,7 @@ public:
 	}
 
 	CUDA_DEVICE_CALLABLE void operator()(
-		cudf::size_type row_index, int64_t total_buffer[], cudf::size_type size) {
+		cudf::size_type row_index, int64_t total_buffer[], cudf::size_type size, curandState & state) {
 		cudf::bitmask_type * valids_in_buffer =
 			temp_valids_in_buffer + (blockIdx.x * blockDim.x + threadIdx.x) * table.num_columns();
 		cudf::bitmask_type * valids_out_buffer =
@@ -179,7 +193,7 @@ public:
 			}
 
 			for(int16_t op_index = 0; op_index < num_operations; op_index++) {
-				process_operator(op_index, total_buffer, row_index + row, cur_row_valids);
+				process_operator(op_index, total_buffer, row_index + row, cur_row_valids,state );
 			}
 
 			// copy data and row valids into buffer
@@ -377,35 +391,35 @@ private:
 	}
 
 	CUDA_DEVICE_CALLABLE void process_operator(
-		size_t op_index, int64_t * buffer, cudf::size_type row_index, uint64_t & row_valids) {
+		size_t op_index, int64_t * buffer, cudf::size_type row_index, uint64_t & row_valids, curandState & state) {
 		cudf::type_id type = input_types_left[op_index];
 		if(is_float_type(type)) {
-			process_operator_1<double>(op_index, buffer, row_index, row_valids);
+			process_operator_1<double>(op_index, buffer, row_index, row_valids,state);
 		} else {
-			process_operator_1<int64_t>(op_index, buffer, row_index, row_valids);
+			process_operator_1<int64_t>(op_index, buffer, row_index, row_valids,state);
 		}
 	}
 
 	template <typename LeftType>
 	CUDA_DEVICE_CALLABLE void process_operator_1(
-		size_t op_index, int64_t * buffer, cudf::size_type row_index, uint64_t & row_valids) {
+		size_t op_index, int64_t * buffer, cudf::size_type row_index, uint64_t & row_valids, curandState & state) {
 		cudf::type_id type = input_types_right[op_index];
 		if(is_float_type(type)) {
-			process_operator_2<LeftType, double>(op_index, buffer, row_index, row_valids);
+			process_operator_2<LeftType, double>(op_index, buffer, row_index, row_valids,state);
 		} else {
-			process_operator_2<LeftType, int64_t>(op_index, buffer, row_index, row_valids);
+			process_operator_2<LeftType, int64_t>(op_index, buffer, row_index, row_valids,state);
 		}
 	}
 
 	template <typename LeftType, typename RightType>
 	CUDA_DEVICE_CALLABLE void process_operator_2(
-		size_t op_index, int64_t * buffer, cudf::size_type row_index, uint64_t & row_valids) {
+		size_t op_index, int64_t * buffer, cudf::size_type row_index, uint64_t & row_valids, curandState & state) {
 		column_index_type left_position = left_input_positions[op_index];
 		column_index_type right_position = right_input_positions[op_index];
 		column_index_type output_position = output_positions[op_index];
 		operator_type oper = operations[op_index];
 
-		if(right_position != UNARY_INDEX) {
+		if(right_position != UNARY_INDEX && right_position != NULLARY_INDEX) {
 			// It's a binary operation
 
 			cudf::type_id left_type_id = input_types_left[op_index];
@@ -590,7 +604,7 @@ private:
 			} else {
 				setColumnValid(row_valids, output_position, false);
 			}
-		} else {
+		} else if( right_position != NULLARY_INDEX) {
 			// It's a unary operation, scalar inputs are not allowed
 			assert(left_position >= 0);
 
@@ -754,6 +768,12 @@ private:
 
 			bool out_valid = (oper == operator_type::BLZ_IS_NULL || oper == operator_type::BLZ_IS_NOT_NULL) ? true : left_valid;
 			setColumnValid(row_valids, output_position, out_valid);
+		}else{
+			if(oper == operator_type::BLZ_RAND) {
+				double out = curand_uniform_double(&state);
+				store_data_in_buffer(out, buffer, output_position);
+			}
+			setColumnValid(row_valids, output_position, true);
 		}
 	}
 
@@ -780,12 +800,20 @@ private:
 	cudf::bitmask_type * temp_valids_out_buffer;
 };
 
-__global__ void transformKernel(InterpreterFunctor op, cudf::size_type size) {
+
+__global__ void transformKernel(InterpreterFunctor op, cudf::size_type size, curandState *state) {
 	extern __shared__ int64_t total_buffer[];
 
+    int id = threadIdx.x + blockIdx.x * blockDim.x;
+    
+
+    curandState localState = state[id];
+ 
+
 	for(cudf::size_type i = (blockIdx.x * blockDim.x + threadIdx.x) * 32; i < size; i += blockDim.x * gridDim.x * 32) {
-		op(i, total_buffer, size);
+		op(i, total_buffer, size, localState);
 	}
+	state[id] = localState;
 }
 
 } // namespace interops

--- a/engine/src/execution_graph/logic_controllers/LogicalProject.cpp
+++ b/engine/src/execution_graph/logic_controllers/LogicalProject.cpp
@@ -693,7 +693,8 @@ std::vector<std::unique_ptr<ral::frame::BlazingColumn>> evaluate_expressions(
                                                 final_output_positions,
                                                 operators,
                                                 left_scalars,
-                                                right_scalars);
+                                                right_scalars,
+                                                table.num_rows());
     }
 
     return std::move(out_columns);

--- a/engine/src/execution_graph/logic_controllers/LogicalProject.cpp
+++ b/engine/src/execution_graph/logic_controllers/LogicalProject.cpp
@@ -535,9 +535,11 @@ public:
 		operator_type op = map_to_operator_type(node.value);
 		if(is_binary_operator(op)) {
 			output_type = cudf::data_type{get_output_type(op, node_to_type_map_.at(node.children[0].get()).id(), node_to_type_map_.at(node.children[1].get()).id())};
-		} else {
+		} else if (is_unary_operator(op)) {
 			output_type = cudf::data_type{get_output_type(op, node_to_type_map_.at(node.children[0].get()).id())};
-		}
+		}else{
+            output_type = cudf::data_type{get_output_type(op)};
+        }
 
 		node_to_type_map_.insert({&node, output_type});
 		expr_output_type_ = output_type;

--- a/engine/src/parser/expression_utils.cpp
+++ b/engine/src/parser/expression_utils.cpp
@@ -7,6 +7,16 @@
 #include "CalciteExpressionParsing.h"
 #include "error.hpp"
 
+bool is_nullary_operator(operator_type op){
+switch (op)
+	{
+	case operator_type::BLZ_RAND:
+		return true;
+	default:
+		return false;
+	}	
+}
+
 bool is_unary_operator(operator_type op) {
 	switch (op)
 	{
@@ -80,6 +90,17 @@ bool is_binary_operator(operator_type op) {
 		return true;
 	default:
 		return false;
+	}
+}
+
+cudf::type_id get_output_type(operator_type op) {
+	switch (op)
+	{
+	case operator_type::BLZ_RAND:
+		return cudf::type_id::FLOAT64;
+	default:
+	 	assert(false);
+		return cudf::type_id::EMPTY;
 	}
 }
 
@@ -203,6 +224,9 @@ cudf::type_id get_output_type(operator_type op, cudf::type_id input_left_type, c
 
 operator_type map_to_operator_type(const std::string & operator_token) {
 	static std::map<std::string, operator_type> OPERATOR_MAP = {
+		// Nullary operators
+		{"BLZ_RND", operator_type::BLZ_RAND},
+
 		// Unary operators
 		{"NOT", operator_type::BLZ_NOT},
 		{"IS NOT TRUE", operator_type::BLZ_NOT},
@@ -514,7 +538,7 @@ std::string replace_calcite_regex(const std::string & expression) {
 	StringUtil::findAndReplaceAll(ret, "IS NOT NULL", "IS_NOT_NULL");
 	StringUtil::findAndReplaceAll(ret, "IS NULL", "IS_NULL");
 	StringUtil::findAndReplaceAll(ret, " NOT NULL", "");
-
+	StringUtil::findAndReplaceAll(ret, "RAND()", "BLZ_RND()");
 	StringUtil::findAndReplaceAll(ret, "EXTRACT(FLAG(YEAR), ", "BL_YEAR(");
 	StringUtil::findAndReplaceAll(ret, "EXTRACT(FLAG(MONTH), ", "BL_MONTH(");
 	StringUtil::findAndReplaceAll(ret, "EXTRACT(FLAG(DAY), ", "BL_DAY(");

--- a/engine/src/parser/expression_utils.hpp
+++ b/engine/src/parser/expression_utils.hpp
@@ -8,6 +8,9 @@
 enum class operator_type {
 	BLZ_INVALID_OP,
 
+	// Nullary operators
+	BLZ_RAND,
+
 	// Unary operators
 	BLZ_NOT,
 	BLZ_ABS,
@@ -67,11 +70,14 @@ enum class operator_type {
 	BLZ_STR_CONCAT
 };
 
+
+bool is_nullary_operator(operator_type op);
 bool is_unary_operator(operator_type op);
 bool is_binary_operator(operator_type op);
 
 cudf::type_id get_output_type(operator_type op, cudf::type_id input_left_type);
 cudf::type_id get_output_type(operator_type op, cudf::type_id input_left_type, cudf::type_id input_right_type);
+cudf::type_id get_output_type(operator_type op);
 
 operator_type map_to_operator_type(const std::string & operator_token);
 

--- a/engine/tests/new-tests/interops_tests.cpp
+++ b/engine/tests/new-tests/interops_tests.cpp
@@ -116,6 +116,70 @@ using namespace interops;
 
 }
 
+TEST_F(OperatorTest, rand_num_2) {
+
+  //hastily assembled assuming nthis goes away when we get the new cudf interpreter
+using namespace interops;
+
+  using T = double;
+  
+  cudf::table_view in_table_view;
+
+  // 0> + * + $0 $1 $2 $1   | + $1 2
+  // 1> + * (+ $0 $1) $2 $1 | + $1 2
+  // 2> + (* $5 $2) $1      | + $1 2
+  // 3> (+ $5 $1)           | (+ $1 2)
+  // 4> $3                  | $4
+
+  std::vector<column_index_type> left_inputs =  { NULLARY_INDEX};
+  std::vector<column_index_type> right_inputs = {NULLARY_INDEX};
+  std::vector<column_index_type> outputs =      { 0 };
+
+  std::vector<column_index_type> final_output_positions = {0};
+
+  std::vector<operator_type> operators = { operator_type::BLZ_RAND};
+
+  auto dtype = cudf::data_type{cudf::type_to_id<T>()};
+  std::unique_ptr<cudf::scalar> arr_s1[] = {cudf::make_numeric_scalar(dtype)};
+  std::vector<std::unique_ptr<cudf::scalar>> left_scalars(std::make_move_iterator(std::begin(arr_s1)), std::make_move_iterator(std::end(arr_s1)));
+  std::unique_ptr<cudf::scalar> arr_s2[] = {cudf::make_numeric_scalar(dtype)};
+  std::vector<std::unique_ptr<cudf::scalar>> right_scalars(std::make_move_iterator(std::begin(arr_s2)), std::make_move_iterator(std::end(arr_s2)));
+
+  cudf::size_type input_rows = 100;
+  
+  // using OUT_T = typename output_type<T>::type;
+  auto sequenceOut = cudf::test::make_counting_transform_iterator(0, [](auto row) {
+      return T{};
+    });
+  cudf::test::fixed_width_column_wrapper<T> out_col1(sequenceOut, sequenceOut + input_rows);
+ 
+  cudf::mutable_table_view out_table_view ({out_col1});
+
+  perform_interpreter_operation(out_table_view,
+                              in_table_view,
+                              left_inputs,
+                              right_inputs,
+                              outputs,
+                              final_output_positions,
+                              operators,
+                              left_scalars,
+                              right_scalars,
+                              input_rows);
+
+   //for (auto &&c : out_table_view) {
+   //    cudf::test::print(c);
+   //    std::cout << std::endl;
+   //}
+  
+
+  std::pair<thrust::host_vector<T>, std::vector<cudf::bitmask_type>> data_mask =  cudf::test::to_host<T>(out_col1);
+
+  for (int i = 0; i < data_mask.first.size(); i++){
+    ASSERT_TRUE(data_mask.first[i] >= 0.0d && data_mask.first[i] <= 1.0d);
+  }
+  ASSERT_TRUE(out_table_view.num_rows() == input_rows);
+}
+
 using SignedIntegralTypesNotBool =
   cudf::test::Types<int8_t, int16_t, int32_t, int64_t>;
 using SignedIntegralTypes = cudf::test::Concat<SignedIntegralTypesNotBool, cudf::test::Types<bool>>;

--- a/engine/tests/new-tests/interops_tests.cpp
+++ b/engine/tests/new-tests/interops_tests.cpp
@@ -1,4 +1,6 @@
 #include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/null_mask.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/datetime.hpp>
 #include <cudf/sorting.hpp>
@@ -12,7 +14,7 @@
 #include "tests/utilities/type_list_utilities.hpp"
 #include "Interpreter/interpreter_cpp.h"
 #include "tests/utilities/BlazingUnitTest.h"
-
+#include <thrust/host_vector.h>
 template <typename T>
 struct InteropsTestNumeric : public BlazingUnitTest {
   void SetUp() {
@@ -22,6 +24,97 @@ struct InteropsTestNumeric : public BlazingUnitTest {
     
   }
 };
+
+
+using namespace ral::parser;
+struct OperatorTest : public ::testing::Test {
+	OperatorTest() {}
+
+	~OperatorTest() {}
+};
+
+
+TEST_F(OperatorTest, rand_num_1) {
+
+  //hastily assembled assuming nthis goes away when we get the new cudf interpreter
+using namespace interops;
+
+  using T = double;
+  cudf::size_type inputRows = 10;
+
+  auto sequence1 = cudf::test::make_counting_transform_iterator(0, [](auto row) {
+      return static_cast<T>(row * 2);
+    });
+  cudf::test::fixed_width_column_wrapper<T> col1(sequence1, sequence1 + inputRows);
+
+  auto sequence2 = cudf::test::make_counting_transform_iterator(0, [](auto row) {
+      return static_cast<T>(row * 10);
+    });
+  cudf::test::fixed_width_column_wrapper<T> col2(sequence2, sequence2 + inputRows);
+
+  auto sequence3 = cudf::test::make_counting_transform_iterator(0, [](auto row) {
+      return static_cast<T>(row * 20);
+    });
+  cudf::test::fixed_width_column_wrapper<T> col3(sequence3, sequence3 + inputRows);
+  
+  cudf::table_view in_table_view ({col1, col2, col3});
+
+  // 0> + * + $0 $1 $2 $1   | + $1 2
+  // 1> + * (+ $0 $1) $2 $1 | + $1 2
+  // 2> + (* $5 $2) $1      | + $1 2
+  // 3> (+ $5 $1)           | (+ $1 2)
+  // 4> $3                  | $4
+
+  std::vector<column_index_type> left_inputs =  {0, 5, 5,      NULLARY_INDEX};
+  std::vector<column_index_type> right_inputs = {1, 2, 1,      NULLARY_INDEX};
+  std::vector<column_index_type> outputs =      {5, 5, 3,      4};
+
+  std::vector<column_index_type> final_output_positions = {3, 4};
+
+  std::vector<operator_type> operators = {operator_type::BLZ_ADD, operator_type::BLZ_MUL, operator_type::BLZ_ADD, operator_type::BLZ_RAND};
+
+  auto dtype = cudf::data_type{cudf::type_to_id<T>()};
+  std::unique_ptr<cudf::scalar> arr_s1[] = {cudf::make_numeric_scalar(dtype), cudf::make_numeric_scalar(dtype), cudf::make_numeric_scalar(dtype), cudf::make_numeric_scalar(dtype)};
+  std::vector<std::unique_ptr<cudf::scalar>> left_scalars(std::make_move_iterator(std::begin(arr_s1)), std::make_move_iterator(std::end(arr_s1)));
+  std::unique_ptr<cudf::scalar> arr_s2[] = {cudf::make_numeric_scalar(dtype), cudf::make_numeric_scalar(dtype), cudf::make_numeric_scalar(dtype), cudf::make_numeric_scalar(dtype)};
+  std::vector<std::unique_ptr<cudf::scalar>> right_scalars(std::make_move_iterator(std::begin(arr_s2)), std::make_move_iterator(std::end(arr_s2)));
+  static_cast<cudf::scalar_type_t<T>*>(right_scalars[3].get())->set_value((T)2);
+  
+  // using OUT_T = typename output_type<T>::type;
+  auto sequenceOut = cudf::test::make_counting_transform_iterator(0, [](auto row) {
+      return T{};
+    });
+  cudf::test::fixed_width_column_wrapper<T> out_col1(sequenceOut, sequenceOut + inputRows);
+  cudf::test::fixed_width_column_wrapper<T> out_col2(sequenceOut, sequenceOut + inputRows);
+  cudf::mutable_table_view out_table_view ({out_col1, out_col2});
+
+  perform_interpreter_operation(out_table_view,
+                              in_table_view,
+                              left_inputs,
+                              right_inputs,
+                              outputs,
+                              final_output_positions,
+                              operators,
+                              left_scalars,
+                              right_scalars);
+
+   //for (auto &&c : out_table_view) {
+   //    cudf::test::print(c);
+   //    std::cout << std::endl;
+   //}
+  
+  cudf::test::fixed_width_column_wrapper<T> expected_col1({(T)0, (T)250, (T)980, (T)2190, (T)3880, (T)6050, (T)8700, (T)11830, (T)15440, (T)19530});
+  cudf::test::fixed_width_column_wrapper<T> expected_col2({(T)2, (T)12, (T)22, (T)32, (T)42, (T)52, (T)62, (T)72, (T)82, (T)92});
+  cudf::table_view expected_table_view ({expected_col1, expected_col2});
+
+  std::pair<thrust::host_vector<T>, std::vector<cudf::bitmask_type>> data_mask =  cudf::test::to_host<T>(out_col2);
+
+  for (int i = 0; i < data_mask.first.size(); i++){
+    ASSERT_TRUE(data_mask.first[i] >= 0.0d && data_mask.first[i] <= 1.0d);
+  }
+  //cudf::test::expect_colum_equal(expected_table_view, out_table_view);
+
+}
 
 using SignedIntegralTypesNotBool =
   cudf::test::Types<int8_t, int16_t, int32_t, int64_t>;

--- a/engine/tests/new-tests/process_project.cpp
+++ b/engine/tests/new-tests/process_project.cpp
@@ -199,6 +199,49 @@ TYPED_TEST(ProjectTestNumeric, test_numeric_types6)
     }
 }
 
+
+TYPED_TEST(ProjectTestNumeric, test_numeric_types7)
+{
+    using T = TypeParam;
+
+    cudf::test::fixed_width_column_wrapper<T> col1{{4, 5, 3, 5, 8, 5, 6}, {1, 1, 1, 1, 1, 1, 1}};
+    cudf::test::strings_column_wrapper col2({"b", "d", "a", "d", "l", "d", "k"}, {1, 1, 1, 1, 1, 1, 1});
+    cudf::test::fixed_width_column_wrapper<T> col3{{10, 40, 70, 5, 2, 10, 11}, {1, 1, 1, 1, 1, 1, 1}};
+
+    CudfTableView cudf_table_in_view {{col1, col2, col3}};
+    std::unique_ptr<CudfTable> cudf_table = std::make_unique<CudfTable>(cudf_table_in_view);
+
+    std::vector<std::string> names({"A", "B", "C"});
+    std::unique_ptr<ral::frame::BlazingTable> table = std::make_unique<ral::frame::BlazingTable>(std::move(cudf_table), names);
+
+    std::string query_part = "LogicalProject(EXPR$0=[RAND()], EXPR$1=[*($2, RAND())])";
+    blazingdb::manager::Context * context = nullptr;
+
+    std::unique_ptr<ral::frame::BlazingTable> table_out = ral::processor::process_project(
+        std::move(table), 
+        query_part,
+        context);
+
+  //  for (auto &&c : table_out->toBlazingTableView().view()) {
+  //     cudf::test::print(c);
+  //     std::cout << std::endl;
+  // }
+    //if (std::is_same<T, bool>::value) {
+    //    cudf::test::fixed_width_column_wrapper<bool> expect_col1{{0, 0, 0, 0, 0, 0, 0}, {1, 1, 1, 1, 1, 1, 1}};
+    //    cudf::test::fixed_width_column_wrapper<bool> expect_col3{{1, 1, 1, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 1, 1}};
+    //    CudfTableView expect_cudf_table_view {{expect_col1, expect_col3}};
+
+//        cudf::test::expect_tables_equal(expect_cudf_table_view, table_out->view());
+//    } else {
+//        cudf::test::fixed_width_column_wrapper<bool> expect_col1{{1, 1, 0, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 1, 1}};
+//        cudf::test::fixed_width_column_wrapper<bool> expect_col3{{0, 0, 0, 0, 1, 0, 0}, {1, 1, 1, 1, 1, 1, 1}};
+//        CudfTableView expect_cudf_table_view {{expect_col1, expect_col3}};
+
+//        cudf::test::expect_tables_equal(expect_cudf_table_view, table_out->view());
+//   }
+}
+
+
 struct ProjectTestString : public BlazingUnitTest {};
 
 TEST_F(ProjectTestString, test_string_like)

--- a/engine/tests/new-tests/process_project.cpp
+++ b/engine/tests/new-tests/process_project.cpp
@@ -241,6 +241,47 @@ TYPED_TEST(ProjectTestNumeric, test_numeric_types7)
 //   }
 }
 
+TYPED_TEST(ProjectTestNumeric, test_rand)
+{
+    using T = TypeParam;
+
+    cudf::test::fixed_width_column_wrapper<T> col1{{4, 5, 3, 5, 8, 5, 6}, {1, 1, 1, 1, 1, 1, 1}};
+    cudf::test::strings_column_wrapper col2({"b", "d", "a", "d", "l", "d", "k"}, {1, 1, 1, 1, 1, 1, 1});
+    cudf::test::fixed_width_column_wrapper<T> col3{{10, 40, 70, 5, 2, 10, 11}, {1, 1, 1, 1, 1, 1, 1}};
+
+    CudfTableView cudf_table_in_view {{col1, col2, col3}};
+    std::unique_ptr<CudfTable> cudf_table = std::make_unique<CudfTable>(cudf_table_in_view);
+
+    std::vector<std::string> names({"A", "B", "C"});
+    std::unique_ptr<ral::frame::BlazingTable> table = std::make_unique<ral::frame::BlazingTable>(std::move(cudf_table), names);
+
+    std::string query_part = "LogicalProject(EXPR$0=[RAND()])";
+    blazingdb::manager::Context * context = nullptr;
+
+    std::unique_ptr<ral::frame::BlazingTable> table_out = ral::processor::process_project(
+        std::move(table), 
+        query_part,
+        context);
+
+    for (auto &&c : table_out->toBlazingTableView().view()) {
+       cudf::test::print(c);
+       std::cout << std::endl;
+   }
+    //if (std::is_same<T, bool>::value) {
+    //    cudf::test::fixed_width_column_wrapper<bool> expect_col1{{0, 0, 0, 0, 0, 0, 0}, {1, 1, 1, 1, 1, 1, 1}};
+    //    cudf::test::fixed_width_column_wrapper<bool> expect_col3{{1, 1, 1, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 1, 1}};
+    //    CudfTableView expect_cudf_table_view {{expect_col1, expect_col3}};
+
+//        cudf::test::expect_tables_equal(expect_cudf_table_view, table_out->view());
+//    } else {
+//        cudf::test::fixed_width_column_wrapper<bool> expect_col1{{1, 1, 0, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 1, 1}};
+//        cudf::test::fixed_width_column_wrapper<bool> expect_col3{{0, 0, 0, 0, 1, 0, 0}, {1, 1, 1, 1, 1, 1, 1}};
+//        CudfTableView expect_cudf_table_view {{expect_col1, expect_col3}};
+
+//        cudf::test::expect_tables_equal(expect_cudf_table_view, table_out->view());
+//   }
+}
+
 
 struct ProjectTestString : public BlazingUnitTest {};
 


### PR DESCRIPTION
users are now able to use the RAND() function in queries both  as an output and as part of an expression. Right now there is a bug where if you do something along the lines of 

In addition users can now also run queries like 
```
select rand(), sin(3.14) * 2 from orders where o_orderkey < 300

```

