### PR TITLE
[REVIEW] concatenating cache improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - #877 round robing dask workers on single gpu queries
 - #880 reraising query errors in context.py
 - #883 add rand() and running unary operations on literals
+- #887 concatenating cache improvement and replacing PartwiseJoin::load_set with a concatenating cache
 
 ## Bug Fixes
 - #774 fixed build issues with latest cudf 0.15 including updating from_cudf

--- a/engine/src/error.hpp
+++ b/engine/src/error.hpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <vector>
 #include <cudf/utilities/error.hpp>
+#include <exception>
 
 #define STRINGIFY_DETAIL(x) #x
 #define RAL_STRINGIFY(x) STRINGIFY_DETAIL(x)
@@ -16,3 +17,18 @@
 #define RAL_FAIL(reason)                              \
   throw cudf::logic_error("Ral failure at: " __FILE__ \
                           ":" CUDF_STRINGIFY(__LINE__) ": " reason)
+
+
+
+struct BlazingMissingMetadataException : public std::exception
+{
+
+  BlazingMissingMetadataException(std::string key) : key{key} {}
+  virtual ~BlazingMissingMetadataException() {}
+  const char * what () const throw ()
+    {
+    	return ("Missing metadata, could not find key " + key).c_str();
+    }
+  private:
+    std::string key;
+};

--- a/engine/src/execution_graph/logic_controllers/BatchJoinProcessing.cpp
+++ b/engine/src/execution_graph/logic_controllers/BatchJoinProcessing.cpp
@@ -1,9 +1,27 @@
+#include "BatchJoinProcessing.h"
 #include <string>
 #include "parser/expression_tree.hpp"
 #include "error.hpp"
 
 namespace ral {
 namespace batch {
+
+
+std::tuple<std::string, std::string, std::string, std::string> parseExpressionToGetTypeAndCondition(const std::string & expression) {
+	std::string modified_expression, condition, filter_statement, join_type, new_join_statement;
+	modified_expression = expression;
+	StringUtil::findAndReplaceAll(modified_expression, "IS NOT DISTINCT FROM", "=");
+	split_inequality_join_into_join_and_filter(modified_expression, new_join_statement, filter_statement);
+
+	// Getting the condition and type of join
+	condition = get_named_expression(new_join_statement, "condition");
+	join_type = get_named_expression(new_join_statement, "joinType");
+
+	if (condition == "true") {
+		join_type = CROSS_JOIN;
+	}		
+	return std::make_tuple(modified_expression, condition, filter_statement, join_type);
+}
 
 void parseJoinConditionToColumnIndices(const std::string & condition, std::vector<int> & columnIndices) {
 	// TODO: right now this only works for equijoins

--- a/engine/src/execution_graph/logic_controllers/BatchJoinProcessing.h
+++ b/engine/src/execution_graph/logic_controllers/BatchJoinProcessing.h
@@ -76,9 +76,9 @@ public:
 		this->condition = get_named_expression(new_join_statement, "condition");
 		this->join_type = get_named_expression(new_join_statement, "joinType");
 
-		if (condition == "true") {
+		if (this->condition == "true") {
 			this->join_type = CROSS_JOIN;
-		}
+		}		
 	}
 
 	bool can_you_throttle_my_input() {
@@ -468,12 +468,12 @@ public:
 		split_inequality_join_into_join_and_filter(this->expression, new_join_statement, filter_statement);
 
 		// Getting the condition and type of join
-		std::string condition = get_named_expression(new_join_statement, "condition");
+		this->condition = get_named_expression(new_join_statement, "condition");
 		this->join_type = get_named_expression(new_join_statement, "joinType");
 
-		if (condition == "true") {
+		if (this->condition == "true") {
 			this->join_type = CROSS_JOIN;
-		}
+		}		
 	}
 
 	bool can_you_throttle_my_input() {

--- a/engine/src/execution_graph/logic_controllers/BatchJoinProcessing.h
+++ b/engine/src/execution_graph/logic_controllers/BatchJoinProcessing.h
@@ -267,6 +267,11 @@ public:
 			try {
 
 				if (left_batch == nullptr && right_batch == nullptr){ // first load
+					
+					// before we load anything, lets make sure each side has data to process
+					this->left_sequence.wait_for_next();
+					this->right_sequence.wait_for_next();
+					
 					left_batch = load_left_set();
 					right_batch = load_right_set();
 					this->max_left_ind = 0; // we have loaded just once. This is the highest index for now

--- a/engine/src/execution_graph/logic_controllers/CacheMachine.cpp
+++ b/engine/src/execution_graph/logic_controllers/CacheMachine.cpp
@@ -27,13 +27,17 @@ std::string randomString(std::size_t length) {
 	return random_string;
 }
 
-size_t CacheDataLocalFile::sizeInBytes() const {
+size_t CacheDataLocalFile::fileSizeInBytes() const {
 	struct stat st;
 
 	if(stat(this->filePath_.c_str(), &st) == 0)
 		return (st.st_size);
 	else
 		throw;
+}
+
+size_t CacheDataLocalFile::sizeInBytes() const {
+	return size_in_bytes;
 }
 
 std::unique_ptr<ral::frame::BlazingTable> CacheDataLocalFile::decache() {
@@ -49,6 +53,7 @@ std::unique_ptr<ral::frame::BlazingTable> CacheDataLocalFile::decache() {
 CacheDataLocalFile::CacheDataLocalFile(std::unique_ptr<ral::frame::BlazingTable> table, std::string orc_files_path)
 	: CacheData(CacheDataType::LOCAL_FILE, table->names(), table->get_schema(), table->num_rows())
 {
+	this->size_in_bytes = table->sizeInBytes();
 	this->filePath_ = orc_files_path + "/.blazing-temp-" + randomString(64) + ".orc";
 
 	std::cout << "CacheDataLocalFile: " << this->filePath_ << std::endl;
@@ -60,7 +65,9 @@ CacheDataLocalFile::CacheDataLocalFile(std::unique_ptr<ral::frame::BlazingTable>
 
 	cudf_io::write_orc(out_args);
 }
-
+std::unique_ptr<GPUCacheDataMetaData> cast_cache_data_to_gpu_with_meta(std::unique_ptr<CacheData> base_pointer){
+	return std::unique_ptr<GPUCacheDataMetaData>(static_cast<GPUCacheDataMetaData *>(base_pointer.release()));
+}
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 CacheMachine::CacheMachine(std::shared_ptr<Context> context): ctx(context), cache_id(CacheMachine::cache_count)
@@ -73,9 +80,7 @@ CacheMachine::CacheMachine(std::shared_ptr<Context> context): ctx(context), cach
 	this->memory_resources.push_back( &blazing_disk_memory_resource::getInstance() );
 	this->num_bytes_added = 0;
 	this->num_rows_added = 0;
-	this->flow_control_batches_threshold = std::numeric_limits<std::uint32_t>::max();
 	this->flow_control_bytes_threshold = std::numeric_limits<std::size_t>::max();
-	this->flow_control_batches_count = 0;
 	this->flow_control_bytes_count = 0;
 
 	logger = spdlog::get("batch_logger");
@@ -85,26 +90,24 @@ CacheMachine::CacheMachine(std::shared_ptr<Context> context): ctx(context), cach
 	kernels_logger = spdlog::get("kernels_logger");
 
 	kernels_logger->info("{ral_id}|{query_id}|{kernel_id}|{is_kernel}|{kernel_type}",
-							"ral_id"_a=context->getNodeIndex(ral::communication::CommunicationData::getInstance().getSelfNode()),
+							"ral_id"_a=(context ? context->getNodeIndex(ral::communication::CommunicationData::getInstance().getSelfNode()) : -1 ),
 							"query_id"_a=(context ? std::to_string(context->getContextToken()) : "null"),
 							"kernel_id"_a=cache_id,
 							"is_kernel"_a=0, //false
 							"kernel_type"_a="cache");
 }
 
-CacheMachine::CacheMachine(std::shared_ptr<Context> context, std::uint32_t flow_control_batches_threshold, std::size_t flow_control_bytes_threshold) : ctx(context), cache_id(CacheMachine::cache_count)
+CacheMachine::CacheMachine(std::shared_ptr<Context> context, std::size_t flow_control_bytes_threshold) : ctx(context), cache_id(CacheMachine::cache_count)
 {
 	CacheMachine::cache_count++;
 
 	waitingCache = std::make_unique<WaitingQueue>();
-	this->memory_resources.push_back( &blazing_device_memory_resource::getInstance() ); 
-	this->memory_resources.push_back( &blazing_host_memory_resource::getInstance() ); 
+	this->memory_resources.push_back( &blazing_device_memory_resource::getInstance() );
+	this->memory_resources.push_back( &blazing_host_memory_resource::getInstance() );
 	this->memory_resources.push_back( &blazing_disk_memory_resource::getInstance() );
 	this->num_bytes_added = 0;
 	this->num_rows_added = 0;
-	this->flow_control_batches_threshold = flow_control_batches_threshold;
 	this->flow_control_bytes_threshold = flow_control_bytes_threshold;
-	this->flow_control_batches_count = 0;
 	this->flow_control_bytes_count = 0;
 
 	logger = spdlog::get("batch_logger");
@@ -133,6 +136,13 @@ std::int32_t CacheMachine::get_id() const { return (cache_id); }
 
 void CacheMachine::finish() {
 	this->waitingCache->finish();
+	logger->trace("{query_id}|{step}|{substep}|{info}|{duration}|cache_id|{cache_id}||",
+									"query_id"_a=(ctx ? std::to_string(ctx->getContextToken()) : ""),
+									"step"_a=(ctx ? std::to_string(ctx->getQueryStep()) : ""),
+									"substep"_a=(ctx ? std::to_string(ctx->getQuerySubstep()) : ""),
+									"info"_a="CacheMachine finish()",
+									"duration"_a="",
+									"cache_id"_a=cache_id);
 }
 
 bool CacheMachine::is_finished() {
@@ -161,7 +171,6 @@ void CacheMachine::addHostFrameToCache(std::unique_ptr<ral::frame::BlazingHostTa
 									"rows"_a=host_table->num_rows());
 
 		std::unique_lock<std::mutex> lock(flow_control_mutex);
-		flow_control_batches_count++;
 		flow_control_bytes_count += host_table->sizeInBytes();
 		lock.unlock();
 
@@ -186,12 +195,11 @@ void CacheMachine::clear() {
 	this->waitingCache->finish();
 }
 
-void CacheMachine::addCacheData(std::unique_ptr<ral::cache::CacheData> cache_data, const std::string & message_id){
+void CacheMachine::addCacheData(std::unique_ptr<ral::cache::CacheData> cache_data, const std::string & message_id, bool always_add){
 
 	// we dont want to add empty tables to a cache, unless we have never added anything
-	if (!this->something_added || cache_data->num_rows() > 0){
+	if ((!this->something_added || cache_data->num_rows() > 0) || always_add){
 		std::unique_lock<std::mutex> lock(flow_control_mutex);
-		flow_control_batches_count++;
 		flow_control_bytes_count += cache_data->sizeInBytes();
 		lock.unlock();
 
@@ -200,7 +208,7 @@ void CacheMachine::addCacheData(std::unique_ptr<ral::cache::CacheData> cache_dat
 		int cacheIndex = 0;
 		while(cacheIndex < this->memory_resources.size()) {
 			auto memory_to_use = (this->memory_resources[cacheIndex]->get_memory_used() + cache_data->sizeInBytes());
-			if( memory_to_use < this->memory_resources[cacheIndex]->get_memory_limit()) {
+			if( memory_to_use < 999999999999) {
 				if(cacheIndex == 0) {
 					logger->trace("{query_id}|{step}|{substep}|{info}|{duration}|kernel_id|{kernel_id}|rows|{rows}",
 						"query_id"_a=(ctx ? std::to_string(ctx->getContextToken()) : ""),
@@ -251,11 +259,15 @@ void CacheMachine::addCacheData(std::unique_ptr<ral::cache::CacheData> cache_dat
 	}
 }
 
-void CacheMachine::addToCache(std::unique_ptr<ral::frame::BlazingTable> table, const std::string & message_id) {
-
+void CacheMachine::addToCache(std::unique_ptr<ral::frame::BlazingTable> table, const std::string & message_id, bool always_add) {
+	std::cout<<"cpp add to cache message="<<message_id<<std::endl;
 	// we dont want to add empty tables to a cache, unless we have never added anything
-	if (!this->something_added || table->num_rows() > 0){
+	if (!this->something_added || table->num_rows() > 0|| always_add){
 		for (auto col_ind = 0; col_ind < table->num_columns(); col_ind++){
+			if (table->view().column(col_ind).offset() > 0){
+				table->ensureOwnership();
+			}
+
 			if (table->view().column(col_ind).offset() > 0){
 				std::string err = "ERROR: Add to CacheMachine into cache table column " + table->names()[col_ind] + " has offset";
 				logger->error("{query_id}|{step}|{substep}|{info}|{duration}|kernel_id|{kernel_id}|offset|{offset}",
@@ -268,13 +280,13 @@ void CacheMachine::addToCache(std::unique_ptr<ral::frame::BlazingTable> table, c
 								"offset"_a=table->view().column(col_ind).offset());
 				throw err;
 			}
-		}
 
+		}
+		std::cout<<"we own the data="<<message_id<<std::endl;
 		std::unique_lock<std::mutex> lock(flow_control_mutex);
-		flow_control_batches_count++;
 		flow_control_bytes_count += table->sizeInBytes();
 		lock.unlock();
-		
+
 		num_rows_added += table->num_rows();
 		num_bytes_added += table->sizeInBytes();
 		int cacheIndex = 0;
@@ -300,6 +312,7 @@ void CacheMachine::addToCache(std::unique_ptr<ral::frame::BlazingTable> table, c
 					auto cache_data = std::make_unique<GPUCacheData>(std::move(fully_owned_table));
 					auto item =	std::make_unique<message>(std::move(cache_data), message_id);
 					this->waitingCache->put(std::move(item));
+					std::cout<<"added to gpu="<<message_id<<std::endl;
 				} else {
 					if(cacheIndex == 1) {
 						logger->trace("{query_id}|{step}|{substep}|{info}|{duration}|kernel_id|{kernel_id}|rows|{rows}",
@@ -357,10 +370,9 @@ std::unique_ptr<ral::frame::BlazingTable> CacheMachine::get_or_wait(size_t index
 	if (message_data == nullptr) {
 		return nullptr;
 	}
-	
+
 	std::unique_ptr<ral::frame::BlazingTable> output = message_data->get_data().decache();
 	std::unique_lock<std::mutex> lock(flow_control_mutex);
-	flow_control_batches_count--;
 	flow_control_bytes_count -= output->sizeInBytes();
 	flow_control_condition_variable.notify_all();
 	return std::move(output);
@@ -383,7 +395,28 @@ std::unique_ptr<ral::frame::BlazingTable> CacheMachine::pullFromCache() {
 
 	std::unique_ptr<ral::frame::BlazingTable> output = message_data->get_data().decache();
 	std::unique_lock<std::mutex> lock(flow_control_mutex);
-	flow_control_batches_count--;
+	flow_control_bytes_count -= output->sizeInBytes();
+	flow_control_condition_variable.notify_all();
+	return std::move(output);
+}
+
+
+std::unique_ptr<ral::cache::CacheData> CacheMachine::pullCacheData(std::string message_id) {
+	std::unique_ptr<message> message_data = waitingCache->get_or_wait(message_id);
+	if (message_data == nullptr) {
+		return nullptr;
+	}
+
+	logger->trace("{query_id}|{step}|{substep}|{info}|{duration}|kernel_id|{kernel_id}|rows|{rows}",
+								"query_id"_a=(ctx ? std::to_string(ctx->getContextToken()) : ""),
+								"step"_a=(ctx ? std::to_string(ctx->getQueryStep()) : ""),
+								"substep"_a=(ctx ? std::to_string(ctx->getQuerySubstep()) : ""),
+								"info"_a="Pull from CacheMachine CacheData object type {}"_format(static_cast<int>(message_data->get_data().get_type())),
+								"duration"_a="",
+								"kernel_id"_a=message_data->get_message_id(),
+								"rows"_a=message_data->get_data().num_rows());
+									std::unique_ptr<ral::cache::CacheData> output = message_data->release_data();
+	std::unique_lock<std::mutex> lock(flow_control_mutex);
 	flow_control_bytes_count -= output->sizeInBytes();
 	flow_control_condition_variable.notify_all();
 	return std::move(output);
@@ -412,13 +445,14 @@ std::unique_ptr<ral::frame::BlazingTable> CacheMachine::pullUnorderedFromCache()
 								"step"_a=(ctx ? std::to_string(ctx->getQueryStep()) : ""),
 								"substep"_a=(ctx ? std::to_string(ctx->getQuerySubstep()) : ""),
 								"info"_a="Pull Unordered from CacheMachine type {}"_format(static_cast<int>(message_data->get_data().get_type())),
+
 								"duration"_a="",
 								"kernel_id"_a=message_data->get_message_id(),
 								"rows"_a=message_data->get_data().num_rows());
 
+
 		std::unique_ptr<ral::frame::BlazingTable> output = message_data->get_data().decache();
 		std::unique_lock<std::mutex> lock(flow_control_mutex);
-		flow_control_batches_count--;
 		flow_control_bytes_count -= output->sizeInBytes();
 		flow_control_condition_variable.notify_all();
 		return std::move(output);
@@ -444,16 +478,15 @@ std::unique_ptr<ral::cache::CacheData> CacheMachine::pullCacheData() {
 
 	std::unique_ptr<ral::cache::CacheData> output = message_data->release_data();
 	std::unique_lock<std::mutex> lock(flow_control_mutex);
-	flow_control_batches_count--;
 	flow_control_bytes_count -= output->sizeInBytes();
 	flow_control_condition_variable.notify_all();
 	return std::move(output);
 }
 
 
-bool CacheMachine::thresholds_are_met(std::uint32_t batches_count, std::size_t bytes_count){
-		
-	return batches_count > this->flow_control_batches_threshold && bytes_count > this->flow_control_bytes_threshold;
+bool CacheMachine::thresholds_are_met(std::size_t bytes_count){
+
+	return bytes_count > this->flow_control_bytes_threshold;
 }
 
 void CacheMachine::wait_if_cache_is_saturated() {
@@ -461,8 +494,8 @@ void CacheMachine::wait_if_cache_is_saturated() {
 	CodeTimer blazing_timer;
 
 	std::unique_lock<std::mutex> lock(flow_control_mutex);
-	while(!flow_control_condition_variable.wait_for(lock, 60000ms, [&, this] { 
-			bool cache_not_saturated = !thresholds_are_met(flow_control_batches_count, flow_control_bytes_count);
+	while(!flow_control_condition_variable.wait_for(lock, 60000ms, [&, this] {
+			bool cache_not_saturated = !thresholds_are_met(flow_control_bytes_count);
 
 			if (!cache_not_saturated && blazing_timer.elapsed_time() > 59000){
 				logger->warn("{query_id}|{step}|{substep}|{info}|{duration}||||",
@@ -540,34 +573,40 @@ size_t CacheMachine::downgradeCacheData() {
 ConcatenatingCacheMachine::ConcatenatingCacheMachine(std::shared_ptr<Context> context)
 	: CacheMachine(context) {}
 
-ConcatenatingCacheMachine::ConcatenatingCacheMachine(std::shared_ptr<Context> context, std::uint32_t flow_control_batches_threshold, std::size_t flow_control_bytes_threshold, bool concat_all)
-	: CacheMachine(context, flow_control_batches_threshold, flow_control_bytes_threshold), concat_all(concat_all) {}
+ConcatenatingCacheMachine::ConcatenatingCacheMachine(std::shared_ptr<Context> context, std::size_t flow_control_bytes_threshold, bool concat_all)
+	: CacheMachine(context, flow_control_bytes_threshold), concat_all(concat_all) {}
 
 // This method does not guarantee the relative order of the messages to be preserved
 std::unique_ptr<ral::frame::BlazingTable> ConcatenatingCacheMachine::pullFromCache() {
-	
+
+	if (concat_all){
+		waitingCache->wait_until_finished();
+	} else {
+		waitingCache->wait_until_num_bytes(this->flow_control_bytes_threshold);
+	}
+
 	size_t total_bytes = 0;
 	std::vector<std::unique_ptr<message>> collected_messages;
 	std::unique_ptr<message> message_data;
 	std::string message_id = "";
-	while (message_data = waitingCache->pop_or_wait())
-	{
-		auto& cache_data = message_data->get_data();
-		if (concat_all || collected_messages.empty() || !thresholds_are_met(1 + collected_messages.size(), total_bytes + cache_data.sizeInBytes())) {
-			total_bytes += cache_data.sizeInBytes();
-			message_id = message_data->get_message_id();
-			collected_messages.push_back(std::move(message_data));
 
-			// we need to decrement here and not at the end, otherwise we can end up with a dead lock
-			std::unique_lock<std::mutex> lock(flow_control_mutex);
-			flow_control_batches_count--;
-			flow_control_bytes_count -= cache_data.sizeInBytes();
-			flow_control_condition_variable.notify_all();
-		} else {
-			waitingCache->put(std::move(message_data));
+	do {
+		message_data = waitingCache->pop_or_wait();
+		if (message_data == nullptr){
 			break;
 		}
-	}
+		auto& cache_data = message_data->get_data();
+		total_bytes += cache_data.sizeInBytes();
+		message_id = message_data->get_message_id();
+		collected_messages.push_back(std::move(message_data));
+
+		// we need to decrement here and not at the end, otherwise we can end up with a dead lock
+		std::unique_lock<std::mutex> lock(flow_control_mutex);
+		flow_control_bytes_count -= cache_data.sizeInBytes();
+		flow_control_condition_variable.notify_all();
+
+	} while (!thresholds_are_met(total_bytes + waitingCache->get_next_size_in_bytes()));
+
 	std::unique_ptr<ral::frame::BlazingTable> output;
 	size_t num_rows = 0;
 	if(collected_messages.empty()){
@@ -598,7 +637,6 @@ std::unique_ptr<ral::frame::BlazingTable> ConcatenatingCacheMachine::pullFromCac
 				collected_messages[i] =	std::make_unique<message>(std::move(cache_data), collected_messages[i]->get_message_id());
 				std::unique_lock<std::mutex> lock(flow_control_mutex);
 				for (; i < collected_messages.size(); i++){
-					flow_control_batches_count++;
 					flow_control_bytes_count += collected_messages[i]->get_data().sizeInBytes();
 					this->waitingCache->put(std::move(collected_messages[i]));
 				}
@@ -616,7 +654,7 @@ std::unique_ptr<ral::frame::BlazingTable> ConcatenatingCacheMachine::pullFromCac
 		}
 		output = ral::utilities::concatTables(table_views);
 		num_rows = output->num_rows();
-	}	
+	}
 
 	logger->trace("{query_id}|{step}|{substep}|{info}|{duration}|kernel_id|{kernel_id}|rows|{rows}",
 								"query_id"_a=(ctx ? std::to_string(ctx->getContextToken()) : ""),

--- a/engine/src/execution_graph/logic_controllers/CacheMachine.cpp
+++ b/engine/src/execution_graph/logic_controllers/CacheMachine.cpp
@@ -56,7 +56,6 @@ CacheDataLocalFile::CacheDataLocalFile(std::unique_ptr<ral::frame::BlazingTable>
 	this->size_in_bytes = table->sizeInBytes();
 	this->filePath_ = orc_files_path + "/.blazing-temp-" + randomString(64) + ".orc";
 
-	std::cout << "CacheDataLocalFile: " << this->filePath_ << std::endl;
 	cudf_io::table_metadata metadata;
 	for(auto name : table->names()) {
 		metadata.column_names.emplace_back(name);
@@ -260,7 +259,6 @@ void CacheMachine::addCacheData(std::unique_ptr<ral::cache::CacheData> cache_dat
 }
 
 void CacheMachine::addToCache(std::unique_ptr<ral::frame::BlazingTable> table, const std::string & message_id, bool always_add) {
-	std::cout<<"cpp add to cache message="<<message_id<<std::endl;
 	// we dont want to add empty tables to a cache, unless we have never added anything
 	if (!this->something_added || table->num_rows() > 0|| always_add){
 		for (auto col_ind = 0; col_ind < table->num_columns(); col_ind++){
@@ -282,7 +280,6 @@ void CacheMachine::addToCache(std::unique_ptr<ral::frame::BlazingTable> table, c
 			}
 
 		}
-		std::cout<<"we own the data="<<message_id<<std::endl;
 		std::unique_lock<std::mutex> lock(flow_control_mutex);
 		flow_control_bytes_count += table->sizeInBytes();
 		lock.unlock();
@@ -312,7 +309,6 @@ void CacheMachine::addToCache(std::unique_ptr<ral::frame::BlazingTable> table, c
 					auto cache_data = std::make_unique<GPUCacheData>(std::move(fully_owned_table));
 					auto item =	std::make_unique<message>(std::move(cache_data), message_id);
 					this->waitingCache->put(std::move(item));
-					std::cout<<"added to gpu="<<message_id<<std::endl;
 				} else {
 					if(cacheIndex == 1) {
 						logger->trace("{query_id}|{step}|{substep}|{info}|{duration}|kernel_id|{kernel_id}|rows|{rows}",

--- a/engine/src/execution_graph/logic_controllers/CacheMachine.h
+++ b/engine/src/execution_graph/logic_controllers/CacheMachine.h
@@ -291,11 +291,11 @@ public:
 
 		std::unique_lock<std::mutex> lock(mutex_);
 		condition_variable_.wait(lock, [&, this] () {
-			std::cout<<"message queue size is "<<this->processed<<std::endl;
-			return count <= this->processed;
+			if (count > this->processed){
+				throw std::runtime_error("WaitingQueue::wait_for_count encountered " + std::to_string(this->processed) + " when expecting " + std::to_string(count));
+			}
+			return count == this->processed;
 		});
-
-
 	}
 
 

--- a/engine/src/execution_graph/logic_controllers/CacheMachine.h
+++ b/engine/src/execution_graph/logic_controllers/CacheMachine.h
@@ -1,5 +1,17 @@
 #pragma once
 
+#include <atomic>
+#include <future>
+#include <memory>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <typeindex>
+#include <vector>
+#include <limits>
+#include <map>
+
 #include <spdlog/spdlog.h>
 #include <spdlog/async.h>
 #include <spdlog/sinks/basic_file_sink.h>
@@ -8,26 +20,20 @@
 #include "cudf/column/column_view.hpp"
 #include "cudf/table/table.hpp"
 #include "cudf/table/table_view.hpp"
+#include <cudf/io/functions.hpp>
+
+#include "error.hpp"
+#include "CodeTimer.h"
+#include <blazingdb/manager/Context.h>
+#include <communication/messages/GPUComponentMessage.h>
 #include "execution_graph/logic_controllers/BlazingColumn.h"
 #include "execution_graph/logic_controllers/BlazingColumnOwner.h"
 #include "execution_graph/logic_controllers/BlazingColumnView.h"
-#include <atomic>
-#include <blazingdb/manager/Context.h>
-#include <cudf/io/functions.hpp>
-#include <future>
-#include <memory>
-#include <condition_variable>
-#include <mutex>
-#include <queue>
-#include <src/communication/messages/GPUComponentMessage.h>
-#include <string>
-#include <typeindex>
-#include <vector>
-#include <limits>
 #include <bmr/BlazingMemoryResource.h>
-#include <spdlog/spdlog.h>
 #include "communication/CommunicationData.h"
-#include "CodeTimer.h"
+
+
+
 using namespace std::chrono_literals;
 
 namespace ral {
@@ -37,7 +43,19 @@ using Context = blazingdb::manager::Context;
 using namespace fmt::literals;
 
 /// \brief An enum type to represent the cache level ID
-enum class CacheDataType { GPU, CPU, LOCAL_FILE };
+enum class CacheDataType { GPU, CPU, LOCAL_FILE, GPU_METADATA };
+
+const std::string KERNEL_ID_METADATA_LABEL = "kernel_id";
+const std::string QUERY_ID_METADATA_LABEL = "query_id";
+const std::string CACHE_ID_METADATA_LABEL = "cache_id";
+const std::string ADD_TO_SPECIFIC_CACHE_METADATA_LABEL = "add_to_specific_cache";
+const std::string SENDER_WORKER_ID_METADATA_LABEL = "sender_worker_id";
+const std::string WORKER_IDS_METADATA_LABEL = "worker_ids";
+const std::string TOTAL_TABLE_ROWS_METADATA_LABEL = "total_table_rows";
+const std::string JOIN_LEFT_BYTES_METADATA_LABEL = "join_left_bytes_metadata_label";
+const std::string JOIN_RIGHT_BYTES_METADATA_LABEL = "join_right_bytes_metadata_label";
+const std::string MESSAGE_ID = "message_id";
+const std::string PARTITION_COUNT = "partition_count";
 
 /// \brief An interface which represent a CacheData
 class CacheData {
@@ -72,11 +90,51 @@ protected:
 	size_t n_rows;
 };
 
+class MetadataDictionary{
+public:
+	void add_value(std::string key, std::string value){
+		this->values[key] = value;
+	}
+
+	void add_value(std::string key, int value){
+		this->values[key] = std::to_string(value);
+	}
+
+
+	int get_kernel_id(){
+		if( this->values.find(KERNEL_ID_METADATA_LABEL) == this->values.end()){
+			throw BlazingMissingMetadataException(KERNEL_ID_METADATA_LABEL);
+		}
+		return std::stoi(values[KERNEL_ID_METADATA_LABEL]);
+	}
+
+	void print(){
+		for(auto elem : this->values)
+		{
+		   std::cout << elem.first << " " << elem.second<< "\n";
+		}
+	}
+	std::map<std::string,std::string> get_values(){
+		return this->values;
+	}
+
+	void set_values(std::map<std::string,std::string> new_values){
+		this->values= new_values;
+		print();
+	}
+private:
+	std::map<std::string,std::string> values;
+};
+
 /// \brief A specific class for a CacheData on GPU Memory
 class GPUCacheData : public CacheData {
 public:
 	GPUCacheData(std::unique_ptr<ral::frame::BlazingTable> table)
 		: CacheData(CacheDataType::GPU,table->names(), table->get_schema(), table->num_rows()),  data{std::move(table)} {}
+
+		GPUCacheData(std::unique_ptr<ral::frame::BlazingTable> table, CacheDataType cache_type_override)
+			: CacheData(cache_type_override,table->names(), table->get_schema(), table->num_rows()),  data{std::move(table)} {}
+
 
 	std::unique_ptr<ral::frame::BlazingTable> decache() override { return std::move(data); }
 
@@ -84,9 +142,38 @@ public:
 
 	virtual ~GPUCacheData() {}
 
-private:
+	ral::frame::BlazingTableView getTableView(){
+		return this->data->toBlazingTableView();
+	}
+
+protected:
 	std::unique_ptr<ral::frame::BlazingTable> data;
 };
+
+class GPUCacheDataMetaData : public GPUCacheData {
+public:
+	GPUCacheDataMetaData(std::unique_ptr<ral::frame::BlazingTable> table, const MetadataDictionary & metadata)
+		: GPUCacheData(std::move(table), CacheDataType::GPU_METADATA),
+		metadata(metadata)
+		 { }
+
+	std::unique_ptr<ral::frame::BlazingTable> decache() override { return std::move(data); }
+
+	std::pair<std::unique_ptr<ral::frame::BlazingTable>,MetadataDictionary > decacheWithMetaData(){
+		 return std::make_pair(std::move(data),this->metadata); }
+
+	size_t sizeInBytes() const override { return data->sizeInBytes(); }
+
+	MetadataDictionary getMetadata(){
+		return this->metadata;
+	}
+
+	virtual ~GPUCacheDataMetaData() {}
+
+private:
+	MetadataDictionary metadata;
+};
+
 
 /// \brief A specific class for a CacheData on CPU Memory
  class CPUCacheData : public CacheData {
@@ -124,11 +211,13 @@ public:
 	std::unique_ptr<ral::frame::BlazingTable> decache() override;
 
 	size_t sizeInBytes() const override;
+	size_t fileSizeInBytes() const;
 	virtual ~CacheDataLocalFile() {}
 	std::string filePath() const { return filePath_; }
 
 private:
 	std::string filePath_;
+	size_t size_in_bytes;
 };
 
 using frame_type = std::unique_ptr<ral::frame::BlazingTable>;
@@ -179,9 +268,13 @@ public:
 	void put(message_ptr item) {
 		std::unique_lock<std::mutex> lock(mutex_);
 		putWaitingQueue(std::move(item));
+		processed++;
 		condition_variable_.notify_all();
+		
 	}
-
+	int processed_parts(){
+		return processed;
+	}
 	void finish() {
 		std::unique_lock<std::mutex> lock(mutex_);
 		this->finished = true;
@@ -192,11 +285,26 @@ public:
 		return this->finished.load(std::memory_order_seq_cst);
 	}
 
+
+
+	void wait_for_count(int count){
+
+		std::unique_lock<std::mutex> lock(mutex_);
+		condition_variable_.wait(lock, [&, this] () {
+			std::cout<<"message queue size is "<<this->processed<<std::endl;
+			return count <= this->processed;
+		});
+
+
+	}
+
+
 	message_ptr pop_or_wait() {		
+
 		CodeTimer blazing_timer;
 		std::unique_lock<std::mutex> lock(mutex_);
-		while(!condition_variable_.wait_for(lock, 60000ms, [&, this] { 
-				bool done_waiting = this->finished.load(std::memory_order_seq_cst) or !this->empty(); 
+		while(!condition_variable_.wait_for(lock, 60000ms, [&, this] {
+				bool done_waiting = this->finished.load(std::memory_order_seq_cst) or !this->empty();
 				if (!done_waiting && blazing_timer.elapsed_time() > 59000){
 					auto logger = spdlog::get("batch_logger");
 					logger->warn("|||{info}|{duration}||||",
@@ -205,7 +313,7 @@ public:
 				}
 				return done_waiting;
 			})){}
-		
+
 		if(this->message_queue_.size() == 0) {
 			return nullptr;
 		}
@@ -217,8 +325,8 @@ public:
 	bool wait_for_next() {
 		CodeTimer blazing_timer;
 		std::unique_lock<std::mutex> lock(mutex_);
-		while(!condition_variable_.wait_for(lock, 60000ms, [&, this] { 
-				bool done_waiting = this->finished.load(std::memory_order_seq_cst) or !this->empty(); 
+		while(!condition_variable_.wait_for(lock, 60000ms, [&, this] {
+				bool done_waiting = this->finished.load(std::memory_order_seq_cst) or !this->empty();
 				if (!done_waiting && blazing_timer.elapsed_time() > 59000){
 					auto logger = spdlog::get("batch_logger");
 					logger->warn("|||{info}|{duration}||||",
@@ -242,8 +350,8 @@ public:
 	void wait_until_finished() {
 		CodeTimer blazing_timer;
 		std::unique_lock<std::mutex> lock(mutex_);
-		while(!condition_variable_.wait_for(lock, 60000ms, [&blazing_timer, this] { 
-				bool done_waiting = this->finished.load(std::memory_order_seq_cst); 
+		while(!condition_variable_.wait_for(lock, 60000ms, [&blazing_timer, this] {
+				bool done_waiting = this->finished.load(std::memory_order_seq_cst);
 				if (!done_waiting && blazing_timer.elapsed_time() > 59000){
 					auto logger = spdlog::get("batch_logger");
 					logger->warn("|||{info}|{duration}||||",
@@ -252,6 +360,37 @@ public:
 				}
 				return done_waiting;
 			})){}
+	}
+
+	void wait_until_num_bytes(size_t num_bytes) {
+		CodeTimer blazing_timer;
+		std::unique_lock<std::mutex> lock(mutex_);
+		while(!condition_variable_.wait_for(lock, 60000ms, [&blazing_timer, num_bytes, this] {
+				bool done_waiting = this->finished.load(std::memory_order_seq_cst);
+				if (!done_waiting) {
+					size_t total_bytes = 0;
+					for (int i = 0; i < message_queue_.size(); i++){
+						total_bytes += message_queue_[i]->get_data().sizeInBytes();
+					}
+					done_waiting = total_bytes > num_bytes;
+				}
+				if (!done_waiting && blazing_timer.elapsed_time() > 59000){
+					auto logger = spdlog::get("batch_logger");
+					logger->warn("|||{info}|{duration}||||",
+										"info"_a="WaitingQueue wait_until_finished timed out",
+										"duration"_a=blazing_timer.elapsed_time());
+				}
+				return done_waiting;
+			})){}
+	}
+
+	size_t get_next_size_in_bytes(){
+		std::unique_lock<std::mutex> lock(mutex_);
+		if (message_queue_.size() > 0){
+			message_queue_[0]->get_data().sizeInBytes();
+		} else {
+			return 0;
+		}
 	}
 
 	message_ptr get_or_wait(std::string message_id) {
@@ -294,8 +433,8 @@ public:
 	std::vector<message_ptr> get_all_or_wait() {
 		CodeTimer blazing_timer;
 		std::unique_lock<std::mutex> lock(mutex_);
-		while(!condition_variable_.wait_for(lock, 60000ms,  [&blazing_timer, this] { 
-				bool done_waiting = this->finished.load(std::memory_order_seq_cst); 
+		while(!condition_variable_.wait_for(lock, 60000ms,  [&blazing_timer, this] {
+				bool done_waiting = this->finished.load(std::memory_order_seq_cst);
 				if (!done_waiting && blazing_timer.elapsed_time() > 59000){
 					auto logger = spdlog::get("batch_logger");
 					logger->warn("|||{info}|{duration}||||",
@@ -340,7 +479,12 @@ private:
 	std::deque<message_ptr> message_queue_;
 	std::atomic<bool> finished;
 	std::condition_variable condition_variable_;
+	int processed = 0;
 };
+
+
+
+std::unique_ptr<GPUCacheDataMetaData> cast_cache_data_to_gpu_with_meta(std::unique_ptr<CacheData>  base_pointer);
 /**
 	@brief A class that represents a Cache Machine on a
 	multi-tier (GPU memory, CPU memory, Disk memory) cache system.
@@ -349,7 +493,7 @@ class CacheMachine {
 public:
 	CacheMachine(std::shared_ptr<Context> context);
 
-	CacheMachine(std::shared_ptr<Context> context, std::uint32_t flow_control_batches_threshold, std::size_t flow_control_bytes_threshold);
+	CacheMachine(std::shared_ptr<Context> context, std::size_t flow_control_bytes_threshold);
 
 	~CacheMachine();
 
@@ -359,9 +503,9 @@ public:
 
 	virtual void clear();
 
-	virtual void addToCache(std::unique_ptr<ral::frame::BlazingTable> table, const std::string & message_id = "");
+	virtual void addToCache(std::unique_ptr<ral::frame::BlazingTable> table, const std::string & message_id = "", bool always_add = false);
 
-	virtual void addCacheData(std::unique_ptr<ral::cache::CacheData> cache_data, const std::string & message_id = "");
+	virtual void addCacheData(std::unique_ptr<ral::cache::CacheData> cache_data, const std::string & message_id = "", bool always_add = false);
 
 	virtual void addHostFrameToCache(std::unique_ptr<ral::frame::BlazingHostTable> table, const std::string & message_id = "");
 
@@ -388,14 +532,22 @@ public:
 	}
 	virtual std::unique_ptr<ral::frame::BlazingTable> pullFromCache();
 
+
+	virtual std::unique_ptr<ral::cache::CacheData> pullCacheData(std::string message_id);
+
 	virtual std::unique_ptr<ral::frame::BlazingTable> pullUnorderedFromCache();
+
 
 	virtual std::unique_ptr<ral::cache::CacheData> pullCacheData();
 
-	bool thresholds_are_met(std::uint32_t batches_count, std::size_t bytes_count);
-	
+
+	bool thresholds_are_met(std::size_t bytes_count);
+
 	virtual void wait_if_cache_is_saturated();
 
+	void wait_for_count(int count){
+		return this->waitingCache->wait_for_count(count);
+	}
 	// take the first cacheData in this CacheMachine that it can find (looking in reverse order) that is in the GPU put it in RAM or Disk as oppropriate
 	// this function does not change the order of the caches
 	virtual size_t downgradeCacheData();
@@ -418,9 +570,7 @@ protected:
 	std::shared_ptr<spdlog::logger> cache_events_logger;
 	const std::size_t cache_id;
 
-	std::uint32_t flow_control_batches_threshold;
 	std::size_t flow_control_bytes_threshold;
-	std::uint32_t flow_control_batches_count;
 	std::size_t flow_control_bytes_count;
 	std::mutex flow_control_mutex;
 	std::condition_variable flow_control_condition_variable;
@@ -529,7 +679,7 @@ class ConcatenatingCacheMachine : public CacheMachine {
 public:
 	ConcatenatingCacheMachine(std::shared_ptr<Context> context);
 
-	ConcatenatingCacheMachine(std::shared_ptr<Context> context, std::uint32_t flow_control_batches_threshold, std::size_t flow_control_bytes_threshold, bool concat_all);
+	ConcatenatingCacheMachine(std::shared_ptr<Context> context, std::size_t flow_control_bytes_threshold, bool concat_all);
 
 	~ConcatenatingCacheMachine() = default;
 
@@ -547,6 +697,9 @@ public:
 	bool concat_all;
 
 };
+
+
+
 
 }  // namespace cache
 } // namespace ral

--- a/engine/src/execution_graph/logic_controllers/LogicPrimitives.cpp
+++ b/engine/src/execution_graph/logic_controllers/LogicPrimitives.cpp
@@ -31,6 +31,12 @@ BlazingTable::BlazingTable(const CudfTableView & table, const std::vector<std::s
 	this->columnNames = columnNames;
 }
 
+void BlazingTable::ensureOwnership(){
+	for (size_t i = 0; i < columns.size(); i++){
+		columns[i] = std::make_unique<BlazingColumnOwner>(std::move(columns[i]->release()));
+	}
+}
+
 CudfTableView BlazingTable::view() const{
 	std::vector<CudfColumnView> column_views(columns.size());
 	for (size_t i = 0; i < columns.size(); i++){

--- a/engine/src/execution_graph/logic_controllers/LogicPrimitives.h
+++ b/engine/src/execution_graph/logic_controllers/LogicPrimitives.h
@@ -58,6 +58,7 @@ public:
 	std::vector<std::unique_ptr<BlazingColumn>> releaseBlazingColumns();
 
 	unsigned long long sizeInBytes();
+	void ensureOwnership();
 
 private:
 	std::vector<std::string> columnNames;

--- a/engine/src/execution_graph/logic_controllers/PhysicalPlanGenerator.h
+++ b/engine/src/execution_graph/logic_controllers/PhysicalPlanGenerator.h
@@ -300,8 +300,28 @@ struct tree_processor {
 			} else {
 				auto child_kernel_type = child->kernel_unit->get_type_id();
 				auto parent_kernel_type = parent->kernel_unit->get_type_id();
-				if ((child_kernel_type == kernel_type::JoinPartitionKernel && parent_kernel_type == kernel_type::PartwiseJoinKernel)
-					    || (child_kernel_type == kernel_type::SortAndSampleKernel &&	parent_kernel_type == kernel_type::PartitionKernel)
+				if (child_kernel_type == kernel_type::JoinPartitionKernel && parent_kernel_type == kernel_type::PartwiseJoinKernel) {
+
+					std::size_t max_data_load_concat_cache_bytes_size = 400000000; // 400 MB
+					config_options = context->getConfigOptions();
+					it = config_options.find("JOIN_PARTITION_SIZE_THRESHOLD");
+					if (it != config_options.end()){
+						max_data_load_concat_cache_bytes_size = std::stoull(config_options["JOIN_PARTITION_SIZE_THRESHOLD"]);
+					}
+
+					auto join_type = static_cast<PartwiseJoin*>(parent->kernel_unit.get())->get_join_type();					
+					bool left_concat_all = join_type == ral::batch::LEFT_JOIN || join_type == ral::batch::OUTER_JOIN || join_type == ral::batch::CROSS_JOIN;
+					bool right_concat_all = join_type == ral::batch::RIGHT_JOIN || join_type == ral::batch::OUTER_JOIN || join_type == ral::batch::CROSS_JOIN;
+					cache_settings left_cache_machine_config = cache_settings{.type = CacheType::CONCATENATING, .num_partitions = 1, .context = context->clone(),
+						.flow_control_bytes_threshold = max_data_load_concat_cache_bytes_size, .concat_all = left_concat_all};
+					cache_settings right_cache_machine_config = cache_settings{.type = CacheType::CONCATENATING, .num_partitions = 1, .context = context->clone(),
+						.flow_control_bytes_threshold = max_data_load_concat_cache_bytes_size, .concat_all = right_concat_all};
+					
+					query_graph += link((*(child->kernel_unit))["output_a"], (*(parent->kernel_unit))["input_a"], left_cache_machine_config);
+					query_graph += link((*(child->kernel_unit))["output_b"], (*(parent->kernel_unit))["input_b"], right_cache_machine_config);
+
+
+				} else if ((child_kernel_type == kernel_type::SortAndSampleKernel &&	parent_kernel_type == kernel_type::PartitionKernel)
 						|| (child_kernel_type == kernel_type::SortAndSampleKernel &&	parent_kernel_type == kernel_type::PartitionSingleNodeKernel)) {
 
 					if (parent->kernel_unit->can_you_throttle_my_input()){

--- a/engine/src/execution_graph/logic_controllers/taskflow/graph.h
+++ b/engine/src/execution_graph/logic_controllers/taskflow/graph.h
@@ -11,9 +11,9 @@ class kernel;
 static std::shared_ptr<ral::cache::CacheMachine> create_cache_machine( const cache_settings& config) {
 	std::shared_ptr<ral::cache::CacheMachine> machine;
 	if (config.type == CacheType::SIMPLE or config.type == CacheType::FOR_EACH) {
-		machine =  std::make_shared<ral::cache::CacheMachine>(config.context, config.flow_control_batches_threshold, config.flow_control_bytes_threshold);
+		machine =  std::make_shared<ral::cache::CacheMachine>(config.context, config.flow_control_bytes_threshold);
 	} else if (config.type == CacheType::CONCATENATING) {
-		machine =  std::make_shared<ral::cache::ConcatenatingCacheMachine>(config.context, config.flow_control_batches_threshold, config.flow_control_bytes_threshold, config.concat_all);
+		machine =  std::make_shared<ral::cache::ConcatenatingCacheMachine>(config.context, config.flow_control_bytes_threshold, config.concat_all);
 	}
 	return machine;
 }

--- a/engine/src/execution_graph/logic_controllers/taskflow/kpair.h
+++ b/engine/src/execution_graph/logic_controllers/taskflow/kpair.h
@@ -19,7 +19,6 @@ struct cache_settings {
 	CacheType type = CacheType::SIMPLE;
 	int num_partitions = 1;
 	std::shared_ptr<Context> context;
-	std::uint32_t flow_control_batches_threshold = std::numeric_limits<std::uint32_t>::max();
 	std::size_t flow_control_bytes_threshold = std::numeric_limits<std::size_t>::max();
 	bool concat_all = false; //applicable only for concatenating caches
 };

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -1034,10 +1034,6 @@ class BlazingContext(object):
             MAX_DATA_LOAD_CONCAT_CACHE_BYTE_SIZE : The max size in bytes to
                     concatenate the batches read from the scan kernels
                     default: 400000000
-            FLOW_CONTROL_BATCHES_THRESHOLD : If an output cache surpasses this
-                    value in num batches, the kernel will try to stop
-                    execution until the output cache contains less.
-                    default: max int (makes it not applicable)
             FLOW_CONTROL_BYTES_THRESHOLD: If an output cache surpasses this
                     value in bytes, the kernel will try to stop
                     execution until the output cache contains less.


### PR DESCRIPTION
This PR brings over the CacheMachine code from the UCX branch.
It also improves ConcatenatingCache::pullFromCache to not decache until necessary
It also replaces PartwiseJoin::load_set with a concatenating cache on each input of PartwiseJoin
It also gets rid of flow control batch count, so that flow control feature only now works using bytes count. (with default parameters that was not being used anyways). This was removed to reduce code complexity.