### PR TITLE
`std::endl` to `'\n'`

### DIFF
--- a/comms/src/blazingdb/transport/Client.cc
+++ b/comms/src/blazingdb/transport/Client.cc
@@ -61,7 +61,7 @@ public:
     zmq::message_t local_message;
     auto success = socket_ptr->recv(local_message);
     if (success.value() == false || local_message.size() == 0) {
-      std::cerr << "Client:   throw zmq::error_t()" << std::endl;
+      std::cerr << "Client:   throw zmq::error_t()" << '\n';
       throw zmq::error_t();
     }
 
@@ -113,7 +113,7 @@ public:
     zmq::message_t local_message;
     auto success = socket_ptr->recv(local_message);
     if (success.value() == false || local_message.size() == 0) {
-      std::cerr << "Client:   throw zmq::error_t()" << std::endl;
+      std::cerr << "Client:   throw zmq::error_t()" << '\n';
       throw zmq::error_t();
     }
 

--- a/comms/src/blazingdb/transport/Server.cc
+++ b/comms/src/blazingdb/transport/Server.cc
@@ -112,7 +112,7 @@ public:
 		try {
 			thread.join();
 		} catch(std::exception & e) {
-			std::cout << "ServerTCP::exception: " << e.what() << std::endl;
+			std::cout << "ServerTCP::exception: " << e.what() << '\n';
 		}
 	}
 
@@ -216,7 +216,7 @@ void ServerTCP::Run() {
 					this->putMessage(message->metadata().contextToken, message);
 				}
 			} catch(const std::runtime_error & exception) {
-				std::cerr << "[ERROR] " << exception.what() << std::endl;
+				std::cerr << "[ERROR] " << exception.what() << '\n';
 				// TODO: write failure
 				throw exception;
 			}
@@ -281,7 +281,7 @@ public:
 						
 					}
 				} catch(const std::runtime_error & exception) {
-					std::cerr << "[ERROR] " << exception.what() << std::endl;
+					std::cerr << "[ERROR] " << exception.what() << '\n';
 					// TODO: write failure
 					throw exception;
 				}

--- a/comms/tests/utils/column_factory.h
+++ b/comms/tests/utils/column_factory.h
@@ -102,7 +102,7 @@ static cudf::table build_table() {
   std::cout << "csv_with_strings\n";
   std::string filename = "/tmp/nation.psv";
   std::ofstream outfile(filename, std::ofstream::out);
-  outfile << content << std::endl;
+  outfile << content << '\n';
   outfile.close();
 
   cudf::csv_read_arg args(cudf::source_info{filename});
@@ -114,7 +114,7 @@ static cudf::table build_table() {
 
   cudf::table table = cudf::read_csv(args);
   std::cout << "table_size: " << table.num_columns() << "|" << table.num_rows()
-            << std::endl;
+            << '\n';
   return transfor_to_nv_category(table);
 }
 

--- a/engine/src/cython/engine.cpp
+++ b/engine/src/cython/engine.cpp
@@ -186,7 +186,7 @@ std::unique_ptr<PartitionedResultSet> runQuery(int32_t masterIndex,
 									"info"_a="In runQuery. What: {}"_format(e.what()),
 									"duration"_a="");
 		logger->flush();
-		std::cerr << e.what() << std::endl;
+		std::cerr << e.what() << '\n';
 		throw;
 	}
 }
@@ -239,7 +239,7 @@ std::unique_ptr<ResultSet> performPartition(int32_t masterIndex,
 		logger->flush();
 
 		std::cerr << "**[performPartition]** error partitioning table.\n";
-		std::cerr << e.what() << std::endl;
+		std::cerr << e.what() << '\n';
 		throw;
 	}
 }
@@ -269,7 +269,7 @@ std::unique_ptr<ResultSet> runSkipData(ral::frame::BlazingTableView metadata,
 		logger->flush();
 		
 		std::cerr << "**[runSkipData]** error parsing metadata.\n";
-		std::cerr << e.what() << std::endl;
+		std::cerr << e.what() << '\n';
 		throw;
 	}
 }

--- a/engine/src/cython/io.cpp
+++ b/engine/src/cython/io.cpp
@@ -151,7 +151,7 @@ std::unique_ptr<ResultSet> parseMetadata(std::vector<std::string> files,
 		result->skipdata_analysis_fail = false;
 		return result;
 	} catch(std::exception e) {
-		std::cerr << e.what() << std::endl;
+		std::cerr << e.what() << '\n';
 		throw e;
 	}
 }

--- a/engine/src/execution_graph/logic_controllers/taskflow/graph.cpp
+++ b/engine/src/execution_graph/logic_controllers/taskflow/graph.cpp
@@ -66,7 +66,7 @@ namespace cache {
 								if(state == kstatus::proceed) {
 									source->output_.finish();
 								} else if (edge.target != -1) { // not a dummy node
-									std::cout<<"ERROR kernel "<<source_id<<" did not finished successfully"<<std::endl;
+									std::cout<<"ERROR kernel "<<source_id<<" did not finished successfully"<<'\n';
 								}
 							});
 							threads.push_back(std::move(t));
@@ -94,7 +94,7 @@ namespace cache {
 		}
 		std::cout << "kernel id -> kernel type id\n";
 		for(kernel * k : kernels_) {
-			std::cout << (int) k->get_id() << " -> " << (int) k->get_type_id() << std::endl;
+			std::cout << (int) k->get_id() << " -> " << (int) k->get_type_id() << '\n';
 		}
 		while(not Q.empty()) {
 			auto source_id = Q.front();
@@ -106,7 +106,7 @@ namespace cache {
 					auto target = get_node(target_id);
 					auto edge_id = std::make_pair(source_id, target_id);
 					if(visited.find(edge_id) == visited.end()) {
-						std::cout << "source_id: " << source_id << " -> " << target_id << std::endl;
+						std::cout << "source_id: " << source_id << " -> " << target_id << '\n';
 						visited.insert(edge_id);
 						Q.push_back(target_id);
 					} else {
@@ -117,7 +117,7 @@ namespace cache {
 	}
 
 	void graph::show_from_kernel (int32_t id) {
-		std::cout<<"show_from_kernel "<<id<<std::endl;
+		std::cout<<"show_from_kernel "<<id<<'\n';
 		check_and_complete_work_flow();
 
 		std::set<std::pair<size_t, size_t>> visited;
@@ -135,7 +135,7 @@ namespace cache {
 					auto source = get_node(source_id);
 					auto edge_id = std::make_pair(target_id, source_id);
 					if(visited.find(edge_id) == visited.end()) {
-						std::cout << "target_id: " << target_id << " <- " << source_id << std::endl;
+						std::cout << "target_id: " << target_id << " <- " << source_id << '\n';
 						visited.insert(edge_id);
 						Q.push_back(source_id);
 					} else {
@@ -181,7 +181,7 @@ namespace cache {
 				return target_kernel->get_estimated_output_num_rows();				
 			}
 		}
-		std::cout<<"ERROR: In get_estimated_input_rows_to_cache could not find edge for kernel "<<id<<" cache "<<port_name<<std::endl;
+		std::cout<<"ERROR: In get_estimated_input_rows_to_cache could not find edge for kernel "<<id<<" cache "<<port_name<<'\n';
 		return std::make_pair(false, 0);
 	}
 

--- a/engine/src/execution_graph/logic_controllers/taskflow/graph.h
+++ b/engine/src/execution_graph/logic_controllers/taskflow/graph.h
@@ -42,7 +42,7 @@ protected:
 		bool operator==(const Edge & e) const { return this->target == e.target && this->source == e.source; }
 
 		void print() const {
-			std::cout<<"Edge: source id: "<<source<<" name: "<<source_port_name<<" target id: "<<target<<" name: "<<target_port_name<<std::endl;
+			std::cout<<"Edge: source id: "<<source<<" name: "<<source_port_name<<" target id: "<<target<<" name: "<<target_port_name<<'\n';
 		}
 	};
 

--- a/engine/src/io/data_parser/ArrowParser.cpp
+++ b/engine/src/io/data_parser/ArrowParser.cpp
@@ -15,7 +15,7 @@ namespace io {
 arrow_parser::arrow_parser(std::shared_ptr< arrow::Table > table):  table(table) {
 	// TODO Auto-generated constructor stub
 
-	std::cout<<"the total num rows is "<<table->num_rows()<<std::endl;
+	std::cout<<"the total num rows is "<<table->num_rows()<<'\n';
 	// WSM TODO table_schema news to be newed up and copy in the properties
 }
 

--- a/engine/tests/cache_machine/generators/file_generator.cpp
+++ b/engine/tests/cache_machine/generators/file_generator.cpp
@@ -33,7 +33,7 @@ data_provider_pair CreateCsvCustomerTableProvider(int index) {
 
 	std::string filename = "/tmp/customer_" + std::to_string(index) + ".psv";
 	std::ofstream outfile(filename, std::ofstream::out);
-	outfile << content << std::endl;
+	outfile << content << '\n';
 	outfile.close();
 
 	std::vector<std::pair<std::string, std::string>> customer_map = {{"c_custkey", "int64"},
@@ -86,7 +86,7 @@ data_provider_pair CreateCsvOrderTableProvider(int index) {
 
 	std::string filename = "/tmp/orders_" + std::to_string(index) + ".psv";
 	std::ofstream outfile(filename, std::ofstream::out);
-	outfile << content << std::endl;
+	outfile << content << '\n';
 	outfile.close();
 
 	std::vector<std::pair<std::string, std::string>> orders_map = {{"o_orderkey", "int64"},
@@ -135,7 +135,7 @@ const std::string content =
 
 	std::string filename = "/tmp/nation_" + std::to_string(index) + ".psv";
 	std::ofstream outfile(filename, std::ofstream::out);
-	outfile << content << std::endl;
+	outfile << content << '\n';
 	outfile.close();
 
 	std::vector<std::pair<std::string, std::string>> columns_map = {

--- a/io/src/FileSystem/private/HadoopFileSystem_p.cpp
+++ b/io/src/FileSystem/private/HadoopFileSystem_p.cpp
@@ -47,8 +47,8 @@ bool HadoopFileSystem::Private::connect(const FileSystemConnection & fileSystemC
 
 	const std::string kerberosTicket = fileSystemConnection.getConnectionProperty(ConnectionProperty::KERBEROS_TICKET);
 
-	std::cout << "Connecting to HDFS server ..." << std::endl;
-	std::cout << fileSystemConnection.toString() << std::endl;
+	std::cout << "Connecting to HDFS server ..." << '\n';
+	std::cout << fileSystemConnection.toString() << '\n';
 
 	arrow::io::HdfsConnectionConfig hdfsConfig;
 	hdfsConfig.host = host;

--- a/io/src/Library/Logging/CoutOutput.cpp
+++ b/io/src/Library/Logging/CoutOutput.cpp
@@ -10,12 +10,12 @@ CoutOutput::~CoutOutput() {}
 
 void CoutOutput::flush(std::string && log) {
 	std::unique_lock<std::mutex> lock(mutex);
-	std::cout << log << std::endl;
+	std::cout << log << '\n';
 }
 
 void CoutOutput::flush(const std::string & log) {
 	std::unique_lock<std::mutex> lock(mutex);
-	std::cout << log << std::endl;
+	std::cout << log << '\n';
 }
 
 void CoutOutput::flush(

--- a/io/src/Library/Logging/FileOutput.cpp
+++ b/io/src/Library/Logging/FileOutput.cpp
@@ -29,19 +29,19 @@ FileOutput::~FileOutput() {}
 
 void FileOutput::flush(std::string && log) {
 	std::unique_lock<std::mutex> lock(mutex);
-	file << log << std::endl;
+	file << log << '\n';
 }
 
 void FileOutput::flush(const std::string & log) {
 	std::unique_lock<std::mutex> lock(mutex);
-	file << log << std::endl;
+	file << log << '\n';
 }
 
 
 void FileOutput::flush(
 	const int nodeInd, const std::string & datetime, const std::string & level, const std::string & log) {
 	std::unique_lock<std::mutex> lock(mutex);
-	file << datetime << "|" << nodeInd << "|" << level << "|" << log << std::endl;
+	file << datetime << "|" << nodeInd << "|" << level << "|" << log << '\n';
 }
 
 // void FileOutput::setNodeIdentifier(const unsigned int nodeInd){


### PR DESCRIPTION
Changed prominent occurrences of `std::endl` to `'\n'`for speed boost. `endl` includes unnecessary `std::flush`. Benchmarks show improved performance.