### PR TITLE
[REVIEW] Use nicer defaults for dask_client and network_interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,16 +23,15 @@
 - #887 concatenating cache improvement and replacing PartwiseJoin::load_set with a concatenating cache
 - #885 Added initial set of unit tests for `WaitingQueue` and nullptr checks around spdlog calls
 - #904 Added doxygen comments to CacheMachine.h
-- #901 Added more documentation about memory management 
-- #910 updated readme 
+- #901 Added more documentation about memory management
+- #910 updated readme
 - #915 Adding max kernel num threads pool
 - #921 Make AWS and GCS optional
 - #925 Replace random_generator with cudf::sample
 - #900 Added doxygen comments to some kernels and the batch processing
 - #936 Adding extern C for include files
 - #941 Logging level (flush_on) can be configurable
-
-
+- #947 Use default client and network interface from Dask
 
 ## Bug Fixes
 - #774 fixed build issues with latest cudf 0.15 including updating from_cudf

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -998,7 +998,8 @@ class BlazingContext(object):
         dask_client (optional) : dask.distributed.Client instance.
                     only necessary for distributed query execution.
                     Set to None if you explicitly dont want it to
-                    connect to any Dask client running, which it will by default.
+                    connect to any Dask client running, which it will by
+                    default.
         network_interface (optional) : for communicating with the
                     dask-scheduler. see note below.
         allocator (optional) :  "managed" or "default" or "existing", where
@@ -1170,6 +1171,7 @@ class BlazingContext(object):
 
             if network_interface is None:
                 import psutil
+
                 local_addr = dask_client.scheduler_comm.comm._local_addr
                 local = local_addr.split("://")[-1].split(":")[0]
                 for name, addrs in psutil.net_if_addrs().items():


### PR DESCRIPTION
This PR does two things to make starting a Dask-powered BlazingContext require less work:

1.  Use `dask.distributed.default_client` to see if there is a default Dask client lying around
2.  Iterate through local network interfaces to find the interface being used to connect to the Dask scheduler

So now if you have some Dask things running

```python
cluster = dask_cuda.LocalCUDACluster()
client = dask.distributed.Client(cluster)
```

Then you should be able to create a `BlazingContext` without parameters

```python
bc = BlazingContext()
```

### Possible Issues 

You all may prefer to be very explicit here.  I think that the network interface code is useful regardless.  However I could imagine an argument for wanting users to opt-in to Dask, even if they have a Dask client around.  

I haven't tested this at all