### PR TITLE
[REVIEW] Handle exceptions from pool_threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 - #952 Dummy PR
 - #957 Fixed issues caused by changes to timespamp in cudf
 - #962 Use new rmm API instead of get_device_resource() and set_device_resource() functions
-
+- #965 Handle exceptions from pool_threads
 
 # BlazingSQL 0.14.0 (June 9, 2020)
 

--- a/engine/bsql_engine/io/cio.pxd
+++ b/engine/bsql_engine/io/cio.pxd
@@ -153,7 +153,7 @@ cdef extern from "../include/engine/engine.h" nogil:
         cdef struct NodeMetaDataTCP:
             string ip
             int communication_port
-        unique_ptr[PartitionedResultSet] runQuery(int masterIndex, vector[NodeMetaDataTCP] tcpMetadata, vector[string] tableNames, vector[string] tableScans, vector[TableSchema] tableSchemas, vector[vector[string]] tableSchemaCppArgKeys, vector[vector[string]] tableSchemaCppArgValues, vector[vector[string]] filesAll, vector[int] fileTypes, int ctxToken, string query, unsigned long accessToken, vector[vector[map[string,string]]] uri_values_cpp, map[string,string] config_options) except +raiseRunQueryError
+        unique_ptr[PartitionedResultSet] runQuery(int masterIndex, vector[NodeMetaDataTCP] tcpMetadata, vector[string] tableNames, vector[string] tableScans, vector[TableSchema] tableSchemas, vector[vector[string]] tableSchemaCppArgKeys, vector[vector[string]] tableSchemaCppArgValues, vector[vector[string]] filesAll, vector[int] fileTypes, int ctxToken, string query, unsigned long accessToken, vector[vector[map[string,string]]] uri_values_cpp, map[string,string] config_options) except +
         unique_ptr[ResultSet] runSkipData(BlazingTableView metadata, vector[string] all_column_names, string query) except +raiseRunSkipDataError
 
         cdef struct TableScanInfo:

--- a/engine/src/distribution/primitives.cpp
+++ b/engine/src/distribution/primitives.cpp
@@ -225,7 +225,7 @@ void distributeTablePartitions(Context * context, std::vector<NodeColumnView> & 
 			try {
 				send_function.get();
 			} catch (std::exception& e) {
-				throw  std::runtime_error("An exception occurred when run() method was called");
+				throw std::runtime_error("An exception occurred when send_function thread was called in distributeTablePartitions");
 			}
 		}
 	}	
@@ -277,7 +277,7 @@ void distributePartitions(Context * context, std::vector<NodeColumnView> & parti
 		try {
 			send_function.get();
 		} catch (std::exception& e) {
-			throw  std::runtime_error("An exception occurred when run() method was called");
+			throw std::runtime_error("An exception occurred when send_function thread was called in distributePartitions");
 		}
 	}
 }
@@ -379,7 +379,7 @@ std::unique_ptr<BlazingTable> getPivotPointsTable(cudf::size_type number_partiti
 }
 
 void broadcastMessage(Context * context, std::vector<Node> nodes,
-			std::shared_ptr<communication::messages::Message> message) {
+	std::shared_ptr<communication::messages::Message> message) {
 	
 	int max_message_threads = 20;
 	std::map<std::string, std::string> config_options = context->getConfigOptions();
@@ -397,7 +397,7 @@ void broadcastMessage(Context * context, std::vector<Node> nodes,
 		try {
 			send_function.get();
 		} catch (std::exception& e) {
-			throw  std::runtime_error("An exception occurred when run() method was called");
+			throw std::runtime_error("An exception occurred when send_function thread was called in broadcastMessage");
 		}
 	}	
 }

--- a/engine/src/execution_graph/logic_controllers/taskflow/graph.cpp
+++ b/engine/src/execution_graph/logic_controllers/taskflow/graph.cpp
@@ -61,7 +61,7 @@ namespace cache {
 						if(visited.find(edge_id) == visited.end()) {
 							visited.insert(edge_id);
 							Q.push_back(target_id);
-							pool.push([this, source, source_id, edge] (int thread_id) {
+							auto run_function = pool.push([this, source, source_id, edge] (int thread_id) {
 								auto state = source->run();
 								if(state == kstatus::proceed) {
 									source->output_.finish();
@@ -69,6 +69,12 @@ namespace cache {
 									std::cout<<"ERROR kernel "<<source_id<<" did not finished successfully"<<std::endl;
 								}
 							});
+
+							try {
+								run_function.get();
+							} catch (std::exception& e) {
+								throw  std::runtime_error("An exception occurred when run() method was called");
+							}
 						} else {
 							// TODO: and circular graph is defined here. Report and error
 						}

--- a/engine/src/utilities/ctpl_stl.h
+++ b/engine/src/utilities/ctpl_stl.h
@@ -78,7 +78,11 @@ namespace ctpl {
 
         // the destructor waits for all the functions in the queue to be finished
         ~thread_pool() {
-            this->stop(true);
+            /* TODO: this is commented out so that if we catch an exception, 
+            we ca throw it and the pool wont try to wait untill all threads are done.
+            This is particularly problematic for the execution kernel threads.
+            If we can get an exception in any kernel to shutdown all kernels then we wont need to comment this out.*/
+            // this->stop(true);
         }
 
         // get the number of running threads in the pool


### PR DESCRIPTION
Throwing manually an exception on the  `run()` method from `BindableTableScan`.

```
BlazingContext ready
[16:05:36.925] [error] 256896318|1|1|In BindableTableScan kernel batch for BindableTableScan(table=[[main, nation]], filters=[[<($1, 3)]], projects=[[0, 2]], aliases=[[n_nationkey, $f1]]). What: Throwing a runtime exception inside BindableTableScan|||||
[16:05:36.926] [error] 256896318|0|0|In execute_plan. What: An exception occurred when run() method was called|||||
An exception occurred when run() method was called[16:05:36.926] [error] 256896318|0|0|In runQuery. What: An exception occurred when run() method was called|||||

>>>>>>>>  [RunQuery Error] An exception occurred when run() method was called
Empty DataFrame
Columns: []
Index: []
Series([], dtype: float64)
```