### PR TITLE
[REVIEW] Remove lock inside grow() method from PinnedBufferProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - #1057 Fixed issue with concat all in concatenating cache
 - #1007 Fix arrow and spdlog compilation issues
 - #1068 Just adds a docs important links and avoid the message about filesystem authority not found
+- #1074: Remove lock inside grow() method from PinnedBufferProvider
 
 
 # BlazingSQL 0.15.0 (August 31, 2020)

--- a/comms/include/blazingdb/transport/io/reader_writer.h
+++ b/comms/include/blazingdb/transport/io/reader_writer.h
@@ -32,6 +32,7 @@ public:
   void freeAll();
 
 private:
+  // Its not threadsafe and the lock needs to be applied before calling it
   void grow();
 
   std::condition_variable cv;

--- a/comms/src/blazingdb/transport/io/reader_writer.cpp
+++ b/comms/src/blazingdb/transport/io/reader_writer.cpp
@@ -69,8 +69,6 @@ PinnedBuffer *PinnedBufferProvider::getBuffer() {
 
 // Will create a new allocation and grow the buffer pool with this->numBuffers/2 new buffers
 void PinnedBufferProvider::grow() {
-  std::unique_lock<std::mutex> lock(inUseMutex);
-   
   PinnedBuffer *buffer = new PinnedBuffer();
   buffer->size = this->bufferSize;
   allocations.resize(allocations.size() + 1);

--- a/comms/src/blazingdb/transport/io/reader_writer.cpp
+++ b/comms/src/blazingdb/transport/io/reader_writer.cpp
@@ -68,6 +68,7 @@ PinnedBuffer *PinnedBufferProvider::getBuffer() {
 
 
 // Will create a new allocation and grow the buffer pool with this->numBuffers/2 new buffers
+// Its not threadsafe and the lock needs to be applied before calling it
 void PinnedBufferProvider::grow() {
   PinnedBuffer *buffer = new PinnedBuffer();
   buffer->size = this->bufferSize;


### PR DESCRIPTION
This PR fix the issue when calling twice to the `std::unique_lock<std::mutex> lock` in the `PinnedBufferProvider`.