### PR TITLE
[REVIEW] Allow to create tables from compressed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # BlazingSQL 0.16.0 (Date TBS)
 
 ## New Features
-
+- #1077 Allow to create tables from compressed files
 
 ## Improvements
 - #997 Add capacity to set the transport memory
@@ -14,9 +14,9 @@
 
 ## Bug Fixes
 - #918 Activate validation for GPU_CI tests results.
-- #975 Fixed issue due to cudf orc api change 
+- #975 Fixed issue due to cudf orc api change
 - #1017 Fixed issue parsing fixed with string literals
-- #1019 Fix hive string col 
+- #1019 Fix hive string col
 - #1021 removed an rmm include
 - #1020 Fixed build issues with latest rmm 0.16 and columnBasisTest due to deprecated drop_column() function
 - #1029 Fix metadata mistmatch due to parsedMetadata
@@ -26,7 +26,7 @@
 - #1030 Avoid read _metadata files
 - #1039 Fixed issues with parsers, in particular ORC parser was misbehaving
 - #1038 Fixed issue with logging dirs in distributed envs
-- #1048 Pinned google cloud version to 1.16 
+- #1048 Pinned google cloud version to 1.16
 - #1052 Partial revert of some changes on parquet rowgroups flow with local_files=True
 - #1054 Can set manually BLAZING_CHACHE_DIRECTORY
 - #1053 Fixed issue when loading paths with wildcards
@@ -70,9 +70,9 @@
 - #936 Adding extern C for include files
 - #941 Logging level (flush_on) can be configurable
 - #947 Use default client and network interface from Dask
-- #945 Added new separate thresh for concat cache 
+- #945 Added new separate thresh for concat cache
 - #939 Add unit test for Project kernel
-- #949 Implemented using threadpool for outgoing messages 
+- #949 Implemented using threadpool for outgoing messages
 - #961 Add list_tables() and describe_table() functions
 - #967 Add bc.get_free_memory() function
 
@@ -108,7 +108,7 @@
 - #927 Fixed random segfault issue in parser
 - #929 Update the GPUManager functions
 - #942 Fix column names on sample function
-- #950 Introducing config param for max orderby samples and fixing oversampling 
+- #950 Introducing config param for max orderby samples and fixing oversampling
 - #952 Dummy PR
 - #957 Fixed issues caused by changes to timespamp in cudf
 - #962 Use new rmm API instead of get_device_resource() and set_device_resource() functions

--- a/engine/bsql_engine/io/io.pyx
+++ b/engine/bsql_engine/io/io.pyx
@@ -19,7 +19,7 @@ from libc.stdlib cimport malloc, free
 from libc.string cimport strcpy, strlen
 from pyarrow.lib cimport *
 
-import enum
+from enum import IntEnum
 
 import numpy as np
 import pandas as pd
@@ -31,6 +31,7 @@ from cudf._lib cimport *
 from cudf._lib.types import np_to_cudf_types, cudf_to_np_types
 from cudf._lib.cpp.types cimport type_id
 from cudf._lib.types cimport underlying_type_t_type_id
+from cudf._lib.cpp.io.types cimport compression_type
 
 from bsql_engine.io cimport cio
 from bsql_engine.io.cio cimport *
@@ -40,6 +41,31 @@ from cython.operator cimport dereference, postincrement
 from cudf._lib.table cimport Table as CudfXxTable
 
 import logging
+
+ctypedef int32_t underlying_type_t_compression
+
+class Compression(IntEnum):
+    INFER = (
+        <underlying_type_t_compression> compression_type.AUTO
+    )
+    SNAPPY = (
+        <underlying_type_t_compression> compression_type.SNAPPY
+    )
+    GZIP = (
+        <underlying_type_t_compression> compression_type.GZIP
+    )
+    BZ2 = (
+        <underlying_type_t_compression> compression_type.BZIP2
+    )
+    BROTLI = (
+        <underlying_type_t_compression> compression_type.BROTLI
+    )
+    ZIP = (
+        <underlying_type_t_compression> compression_type.ZIP
+    )
+    XZ = (
+        <underlying_type_t_compression> compression_type.XZ
+    )
 
 # TODO: module for errors and move pyerrors to cpyerrors
 class BlazingError(Exception):
@@ -116,7 +142,7 @@ cdef cio.TableScanInfo getTableScanInfoPython(string logicalPlan) nogil:
         temp = cio.getTableScanInfo(logicalPlan)
     return temp
 
-cdef void initializePython(int ralId, int gpuId, string network_iface_name, string ralHost, int ralCommunicationPort, bool singleNode, map[string,string] config_options, 
+cdef void initializePython(int ralId, int gpuId, string network_iface_name, string ralHost, int ralCommunicationPort, bool singleNode, map[string,string] config_options,
                             string allocation_mode, size_t initial_pool_size, size_t maximum_pool_size, bool enable_logging) nogil except *:
     with nogil:
         cio.initialize(ralId, gpuId, network_iface_name, ralHost, ralCommunicationPort, singleNode, config_options, allocation_mode, initial_pool_size, maximum_pool_size, enable_logging)
@@ -169,7 +195,7 @@ cpdef pair[bool, string] registerFileSystemCaller(fs, root, authority):
     if fs['type'] == 'local':
         return cio.registerFileSystemLocal( str.encode( root), str.encode(authority))
 
-cpdef initializeCaller(int ralId, int gpuId, string network_iface_name, string ralHost, int ralCommunicationPort, bool singleNode, map[string,string] config_options, 
+cpdef initializeCaller(int ralId, int gpuId, string network_iface_name, string ralHost, int ralCommunicationPort, bool singleNode, map[string,string] config_options,
         string allocation_mode, size_t initial_pool_size, size_t maximum_pool_size, bool enable_logging):
     initializePython(ralId, gpuId, network_iface_name, ralHost, ralCommunicationPort, singleNode, config_options, allocation_mode, initial_pool_size, maximum_pool_size, enable_logging)
 
@@ -199,11 +225,19 @@ cpdef getProductDetailsCaller():
 
 cpdef parseSchemaCaller(fileList, file_format_hint, args, extra_columns, ignore_missing_paths):
     cdef vector[string] files
-    for file in fileList:
-      files.push_back(str.encode(file))
-
     cdef vector[string] arg_keys
     cdef vector[string] arg_values
+    cdef underlying_type_t_compression c_compression
+
+    if 'compression' in args:
+        if args['compression'] is None:
+            c_compression = <underlying_type_t_compression> compression_type.NONE
+        else:
+            c_compression = <underlying_type_t_compression> Compression[args['compression'].upper()]
+        args.update(compression=c_compression)
+
+    for file in fileList:
+      files.push_back(str.encode(file))
 
     for key, value in args.items():
       arg_keys.push_back(str.encode(key))


### PR DESCRIPTION
Fixes #99

Example:

```python
customerColNames = ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment"]
customerColTypes = ["int32", "str", "str", "int32", "str", "float64", "str", "str"]
bc.create_table('orders', ["compressed_file.gz"], delimiter='|', dtype=customerColTypes, names=customerColNames, file_format="csv", compression='gzip')
```