### PR TITLE
deprecating bc.partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - #1132 Refactoring new comms 
 - #1078 Bump junit from 4.12 to 4.13.1 in /algebra
 - #1144 update with changes from main
+- #1158 Deprecated bc.partition 
 
 
 ## Bug Fixes

--- a/pyblazing/pyblazing/apiv2/comms.py
+++ b/pyblazing/pyblazing/apiv2/comms.py
@@ -1,13 +1,13 @@
-from distributed import get_worker
-from distributed.comm.addressing import parse_host_port
-from dask.distributed import default_client
-from ucp.endpoint_reuse import EndpointReuse
-from distributed.comm.ucx import UCXListener
-from distributed.comm.ucx import UCXConnector
-import netifaces as ni
+import errno
 import random
 import socket
-import errno
+
+import netifaces as ni
+from dask.distributed import default_client
+from distributed import get_worker
+from distributed.comm.addressing import parse_host_port
+from distributed.comm.ucx import UCXConnector, UCXListener
+from ucp.endpoint_reuse import EndpointReuse
 
 
 def set_id_mappings_on_worker(mapping):

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -2602,7 +2602,6 @@ class BlazingContext(object):
     def partition(self, input, by=[]):
         print('This function has been Deprecated. It is recommended to use ddf.shuffle(on=[colnames])')
 
-
     def sql(
         self,
         query,

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -2600,7 +2600,9 @@ class BlazingContext(object):
     """
 
     def partition(self, input, by=[]):
-        print('This function has been Deprecated. It is recommended to use ddf.shuffle(on=[colnames])')
+        print(
+            "This function has been Deprecated. It is recommended to use ddf.shuffle(on=[colnames])"
+        )
 
     def sql(
         self,

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -369,33 +369,6 @@ def executeGraph(ctxToken):
     return query_partids, meta, worker.name
 
 
-def collectPartitionsPerformPartition(
-    masterIndex, nodes, ctxToken, input, partition_keys_mapping, df_schema, by, i
-):
-    import dask.distributed
-
-    worker = dask.distributed.get_worker()
-    worker_id = nodes[i]["worker"]
-
-    if worker_id in partition_keys_mapping:
-        partition_keys = partition_keys_mapping[worker_id]
-        if len(partition_keys) > 1:
-            node_inputs = []
-            for key in partition_keys:
-                node_inputs.append(worker.data[key])
-            # TODO, eventually we want the engine side of the
-            # partition function to handle the table in parts
-            node_input = cudf.concat(node_inputs)
-        elif len(partition_keys) == 1:
-            node_input = worker.data[partition_keys[0]]
-        else:
-            node_input = df_schema
-    else:
-        node_input = df_schema
-
-    return cio.performPartitionCaller(masterIndex, nodes, ctxToken, node_input, by)
-
-
 # returns a map of table names to the indices of the columns needed.
 # If there are more than one table scan for one table, it merged the
 # needed columns if the column list is empty, it means we want all columns
@@ -2622,63 +2595,13 @@ class BlazingContext(object):
                     return current_table.getSlicesByWorker(len(self.nodes))
 
     """
-    Partition a dask_cudf DataFrame based on one or more columns.
-
-    Parameters
-    ----------
-
-    input : the dask_cudf.DataFrame you want to partition
-    by : a list of strings of the column names by which you want to partition.
-
-    Examples
-    --------
-
-    >>> bc = BlazingContext(dask_client=client)
-    >>> bc.create_table('product_reviews', "product_reviews/*.parquet")
-    >>> query_1= "SELECT pr_item_sk, pr_review_content, pr_review_sk
-        FROM product_reviews where pr_review_content IS NOT NULL"
-    >>> product_reviews_df = bc.sql(query_1)
-    >>> product_reviews_df = bc.partition(product_reviews_df,
-                                by=["pr_item_sk",
-                                    "pr_review_content",
-                                    "pr_review_sk"])
-    >>> sentences = product_reviews_df.map_partitions(
-                        create_sentences_from_reviews)
+    This function has been Deprecated. It is recommended to use ddf.shuffle(on=[colnames])
 
     """
 
     def partition(self, input, by=[]):
-        masterIndex = 0
-        ctxToken = random.randint(0, np.iinfo(np.int32).max)
+        print('This function has been Deprecated. It is recommended to use ddf.shuffle(on=[colnames])')
 
-        if self.dask_client is None:
-            print("Not supported...")
-        else:
-            if not isinstance(input, dask_cudf.core.DataFrame):
-                print("Not supported...")
-            else:
-                partition_keys_mapping = getNodePartitionKeys(input, self.dask_client)
-                df_schema = input._meta
-
-                dask_futures = []
-                for i, node in enumerate(self.nodes):
-                    worker = node["worker"]
-                    dask_futures.append(
-                        self.dask_client.submit(
-                            collectPartitionsPerformPartition,
-                            masterIndex,
-                            self.nodes,
-                            ctxToken,
-                            input,
-                            partition_keys_mapping,
-                            df_schema,
-                            by,
-                            i,  # node number
-                            workers=[worker],
-                        )
-                    )
-                result = dask.dataframe.from_delayed(dask_futures)
-            return result
 
     def sql(
         self,

--- a/pyblazing/pyblazing/apiv2/filesystem.py
+++ b/pyblazing/pyblazing/apiv2/filesystem.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 
 import cio
-
 from pyblazing.apiv2 import S3EncryptionType
 
 

--- a/pyblazing/pyblazing/test/test_comms.py
+++ b/pyblazing/pyblazing/test/test_comms.py
@@ -1,18 +1,17 @@
 import asyncio
-import pytest
-
-import ucp
-import cudf
-from cudf.tests import utils as cudf_test
 
 import numpy as np
 
+import cudf
+import pytest
+import ucp
+from cudf.tests import utils as cudf_test
 from dask_cuda import LocalCUDACluster
-from distributed import Client, Worker, Scheduler, wait, get_worker
-from distributed.comm import ucx, listen, connect
-from ..apiv2.comms import listen_async, BlazingMessage, UCX, cleanup
+from distributed import Client, Scheduler, Worker, get_worker, wait
+from distributed.comm import connect, listen, ucx
 from distributed.utils_test import cleanup as dask_cleanup  # noqa: 401
 
+from ..apiv2.comms import UCX, BlazingMessage, cleanup, listen_async
 
 enable_tcp_over_ucx = True
 enable_nvlink = False


### PR DESCRIPTION
We can use `ddf.shuffle(on=[colnames])` instead of bc.partition, so we should just deprecate it.

This closes #1011  and #1123 