### PR TITLE
[REVIEW] Removing cuda labels to install due cudatoolkit version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - #1158 Deprecated bc.partition
 - #1154 Recompute the avg_bytes_per_row value
 - #1155 Removing comms subproject and cleaning some related code
-- #1167 Removing cuda labels to install due cudatoolkit version
+- #1186 Removing cuda labels to install due cudatoolkit version
 
 
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - #1158 Deprecated bc.partition
 - #1154 Recompute the avg_bytes_per_row value
 - #1155 Removing comms subproject and cleaning some related code
+- #1167 Removing cuda labels to install due cudatoolkit version
 
 
 ## Bug Fixes

--- a/ci/cpu/upload_anaconda.sh
+++ b/ci/cpu/upload_anaconda.sh
@@ -18,7 +18,7 @@ if [ -z "$MY_UPLOAD_KEY" ]; then
 fi
 
 if [ "$UPLOAD_BLAZING" == "1" ]; then
-    LABEL_OPTION="--label main --label cuda"$CUDA
+    LABEL_OPTION="--label main"
     if [ ! -z "$CUSTOM_LABEL" ]; then
         LABEL_OPTION="--label "$CUSTOM_LABEL
     fi

--- a/conda/recipes/blazingsql/meta.yaml
+++ b/conda/recipes/blazingsql/meta.yaml
@@ -49,6 +49,7 @@ requirements:
         - dask-cuda {{ minor_version }}.*
         - ucx-py {{ minor_version }}.*
         - ucx-proc=*=gpu
+        - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 
 test:
     requires:


### PR DESCRIPTION
This PR allows us to install BlazingSQL without Cuda labels. So this could be the command:
```
$ conda install -c blazingsql-nightly -c rapidsai-nightly -c nvidia -c conda-forge -c defaults blazingsql python=3.8  cudatoolkit=10.2
```
Also this PR fixes #1167 