### PR TITLE
[REVIEW] Enable MySQL-specific SQL operators in addition to Standard and Oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - #1158 Deprecated bc.partition
 - #1154 Recompute the avg_bytes_per_row value
 - #1155 Removing comms subproject and cleaning some related code
+- #1187 Enable MySQL-specific SQL operators in addition to Standard and Oracle
 
 
 ## Bug Fixes

--- a/algebra/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/RelationalAlgebraGenerator.java
+++ b/algebra/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/RelationalAlgebraGenerator.java
@@ -117,7 +117,7 @@ public class RelationalAlgebraGenerator {
 			props.setProperty("defaultSchema", newSchema.getName());
 			List<SqlOperatorTable> sqlOperatorTables = new ArrayList<>();
 			sqlOperatorTables.add(SqlLibraryOperatorTableFactory.INSTANCE.getOperatorTable(
-				EnumSet.of(SqlLibrary.STANDARD, SqlLibrary.ORACLE)));
+				EnumSet.of(SqlLibrary.STANDARD, SqlLibrary.ORACLE, SqlLibrary.MYSQL)));
 			sqlOperatorTables.add(new CalciteCatalogReader(CalciteSchema.from(schema.getSubSchema(newSchema.getName())),
 				defaultSchema,
 				new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT),


### PR DESCRIPTION
This PR:
- Enables MySQL-specific SQL operators, which makes several useful string operators potentially available (REVERSE, LEFT, RIGHT, etc.). Currently only Standard SQL and Oracle SQL are available.

I've confirmed that this change does allow Calcite to use these operators. Passes `./test.sh` locally.

This closes #1178 


```python
from blazingsql import BlazingContext
import pandas as pd

bc = BlazingContext()​
​
df = pd.DataFrame({
    "a": ["one", "two"],
    "b": [1, 2],
})
​
bc.create_table("df", df)
​
query = """
SELECT
    a,
    REVERSE(a)
FROM df
"""

print(bc.explain(query))
LogicalProject(a=[$0], EXPR$1=[REVERSE($0)])
  BindableTableScan(table=[[main, df]], projects=[[0]], aliases=[[a, EXPR$1]])

```
