### PR TITLE
[REVIEW] Implement string REVERSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - #1193 Implement string REPLACE
 - #1201 Implement string TRIM
 - #1216 Add unit test for DAYOFWEEK
+- #1205 Implement string REVERSE
 
 
 ## Improvements

--- a/engine/src/execution_graph/logic_controllers/LogicalProject.cpp
+++ b/engine/src/execution_graph/logic_controllers/LogicalProject.cpp
@@ -440,7 +440,22 @@ std::unique_ptr<cudf::column> evaluate_string_functions(const cudf::table_view &
         
         computed_col = cudf::strings::to_upper(column);
         break;         
-    }        
+    }
+    case operator_type::BLZ_STR_REVERSE:
+    {
+        assert(arg_tokens.size() == 1);
+        RAL_EXPECTS(!is_literal(arg_tokens[0]), "REVERSE operator not supported for literals");
+
+        cudf::column_view column = table.column(get_index(arg_tokens[0]));
+        RAL_EXPECTS(is_type_string(column.type().id()), "REVERSE argument must be a column of type string");
+
+        computed_col = cudf::strings::slice_strings(
+            column,
+            cudf::numeric_scalar<int32_t>(0, false),
+            cudf::numeric_scalar<int32_t>(0, false),
+            cudf::numeric_scalar<int32_t>(-1, true)
+        );
+    }
     }
 
     return computed_col;

--- a/engine/src/parser/expression_utils.cpp
+++ b/engine/src/parser/expression_utils.cpp
@@ -54,6 +54,7 @@ bool is_unary_operator(operator_type op) {
 	case operator_type::BLZ_CHAR_LENGTH:
 	case operator_type::BLZ_STR_LOWER:
 	case operator_type::BLZ_STR_UPPER:
+	case operator_type::BLZ_STR_REVERSE:
 		return true;
 	default:
 		return false;
@@ -131,6 +132,7 @@ cudf::type_id get_output_type(operator_type op, cudf::type_id input_left_type) {
 		return cudf::type_id::TIMESTAMP_NANOSECONDS;
 	case operator_type::BLZ_STR_LOWER:
 	case operator_type::BLZ_STR_UPPER:
+	case operator_type::BLZ_STR_REVERSE:
 	case operator_type::BLZ_CAST_VARCHAR:
 		return cudf::type_id::STRING;
 	case operator_type::BLZ_YEAR:
@@ -277,6 +279,7 @@ operator_type map_to_operator_type(const std::string & operator_token) {
 		{"CHAR_LENGTH", operator_type::BLZ_CHAR_LENGTH},
 		{"LOWER", operator_type::BLZ_STR_LOWER},
 		{"UPPER", operator_type::BLZ_STR_UPPER},
+		{"REVERSE", operator_type::BLZ_STR_REVERSE},
 
 		// Binary operators
 		{"=", operator_type::BLZ_EQUAL},

--- a/engine/src/parser/expression_utils.hpp
+++ b/engine/src/parser/expression_utils.hpp
@@ -46,6 +46,7 @@ enum class operator_type {
 	BLZ_CHAR_LENGTH,
 	BLZ_STR_LOWER,
 	BLZ_STR_UPPER,
+	BLZ_STR_REVERSE,
 
 	// Binary operators
   BLZ_ADD,            ///< operator +

--- a/tests/BlazingSQLTest/EndToEndTests/stringTests.py
+++ b/tests/BlazingSQLTest/EndToEndTests/stringTests.py
@@ -280,6 +280,45 @@ def main(dask_client, drill, spark, dir_data_file, bc, nRals):
                 fileSchemaType,
             )
 
+            queryId = "TEST_14"
+            query = """SELECT
+                REVERSE(c_comment) as reversed_c,
+                SUBSTRING(REVERSE(c_comment), 2, 10) as sub_reversed_c,
+                CAST(SUBSTRING(REVERSE(c_comment), 2, 10) LIKE '%or%' AS INT) as cast_sub_reversed_c
+                FROM customer
+                """
+            runTest.run_query(
+                bc,
+                spark,
+                query,
+                queryId,
+                queryType,
+                worder,
+                "",
+                acceptable_difference,
+                use_percentage,
+                fileSchemaType,
+            )
+
+            queryId = "TEST_15"
+            query = """SELECT
+                COUNT(SUBSTRING(REVERSE(c_comment), 2, 10)) as reverse_subbed_count
+                FROM customer
+                GROUP BY SUBSTRING(REVERSE(c_comment), 2, 10)
+                """
+            runTest.run_query(
+                bc,
+                spark,
+                query,
+                queryId,
+                queryType,
+                worder,
+                "",
+                acceptable_difference,
+                use_percentage,
+                fileSchemaType,
+            )
+
             if Settings.execution_mode == ExecutionMode.GENERATOR:
                 print("==============================")
                 break


### PR DESCRIPTION
This PR:
- [x] Implements the REVERSE unary operator for string columns using cudf::strings::slice_strings
- [x] Adds a new end-to-end test in stringsTests.py, ~and updates the runTest.py~ seems like this PR doesn't need to update the runTest
- [x] Passes tests locally
- [x] PR to update testing files

This closes #1173 

```python
from pyspark.sql import SparkSession
from blazingsql import BlazingContext
import pandas as pd

# spark = SparkSession.builder \
#     .master("local") \
#     .getOrCreate()

# bc = BlazingContext()


df = pd.DataFrame({
    "a": ["Felipe", "William", "Rodrigo"],
    "b": [10, 9, 8],
})

bc.create_table("df", df)
sdf = spark.createDataFrame(df)
sdf.createOrReplaceTempView("df")
​
query = """
SELECT
    a,
    REVERSE(a) as reversed_a
FROM df
"""

spark.sql(query).show()
print(bc.sql(query))

+-------+----------+
|      a|reversed_a|
+-------+----------+
| Felipe|    epileF|
|William|   mailliW|
|Rodrigo|   ogirdoR|
+-------+----------+

         a reversed_a
0   Felipe     epileF
1  William    mailliW
2  Rodrigo    ogirdoR

```