### PR TITLE
[REVIEW] Calcite uses literal as int32 if  not explicit CAST was provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
 - #1199 Fix non thread-safe access to map containing tag to message_metadata for ucx
 - #1196 Fix column_names (table) always as list of string
 - #1203 Changed code back so that parquet is not read a single rowgroup at a time 
-
+- #1207 Calcite uses literal as int32 if not explicit CAST was provided
 
 # BlazingSQL 0.16.0 (October 22, 2020)
 

--- a/engine/src/parser/expression_tree.cpp
+++ b/engine/src/parser/expression_tree.cpp
@@ -227,16 +227,8 @@ cudf::data_type infer_type_from_literal_token(const lexer::token & token) {
       return parsed_double == casted_float ? cudf::data_type{cudf::type_id::FLOAT32} : cudf::data_type{cudf::type_id::FLOAT64};
     } else {
       int64_t parsed_int64 = std::stoll(token_value);
-      return parsed_int64 > std::numeric_limits<int32_t>::max()
-              || parsed_int64 < std::numeric_limits<int32_t>::min()
-                ? cudf::data_type{cudf::type_id::INT64}
-                : parsed_int64 > std::numeric_limits<int16_t>::max()
-                  || parsed_int64 < std::numeric_limits<int16_t>::min()
-                      ? cudf::data_type{cudf::type_id::INT32}
-                      : parsed_int64 > std::numeric_limits<int8_t>::max()
-                        || parsed_int64 < std::numeric_limits<int8_t>::min()
-                          ? cudf::data_type{cudf::type_id::INT16}
-                          : cudf::data_type{cudf::type_id::INT8};
+      // as other SQL engines, defaults to int32
+      return cudf::data_type{cudf::type_id::INT32};
     }
   } else if(token.type == lexer::token_type::Timestamp) {
     const std::string & token_value = token.value;

--- a/engine/tests/new-tests/process_project.cpp
+++ b/engine/tests/new-tests/process_project.cpp
@@ -121,7 +121,7 @@ TYPED_TEST(ProjectTestNumeric, test_numeric_types4)
         query_part,
         context);
 
-    cudf::test::fixed_width_column_wrapper<int8_t> expect_col1{{1, 1, 1, 1, 1, 1, 1}};
+    cudf::test::fixed_width_column_wrapper<int32_t> expect_col1{{1, 1, 1, 1, 1, 1, 1}};
     CudfTableView expect_cudf_table_view {{expect_col1}};
 
     cudf::test::expect_tables_equal(expect_cudf_table_view, table_out->view());
@@ -198,7 +198,6 @@ TYPED_TEST(ProjectTestNumeric, test_numeric_types6)
         cudf::test::expect_tables_equal(expect_cudf_table_view, table_out->view());
     }
 }
-
 
 TYPED_TEST(ProjectTestNumeric, test_numeric_types7)
 {


### PR DESCRIPTION
This PR closes #1041 

By default Calcite uses `int32` for literal values (as long as it does not exceed the limit of an `int32`) 
For each of these queries 
```
query = "select cast(32 as INT) as col_a from df"
query = "select cast(32 as INTEGER) as col_a from df"  
query = "select 32 as col_a from df"  
```

The Relational Algebra returns:
```
DEBUG: com.blazingdb.calcite.application.RelationalAlgebraGenerator - non optimized
LogicalProject(col_a=[32])
  LogicalTableScan(table=[[main, df]])

DEBUG: com.blazingdb.calcite.application.RelationalAlgebraGenerator - optimized
LogicalProject(col_a=[32])
  BindableTableScan(table=[[main, df]], projects=[[]], aliases=[[col_a]])
```

Some of other SQL engines (as `pyspark.sql`) returns also a `int32`, at least you explicitly apply  a `CAST`