### PR TITLE
[WIP] Add support for Calcite Spatial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - #1130 Infer hive folder partition
 - #1188 Implement upper/lower operators
 - #1193 Implement string REPLACE
-
+- #1210 Add support for Calcite Spatial
 
 ## Improvements
 - #878 Adding calcite rule for window functions. (Window functions not supported yet)

--- a/algebra/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/RelationalAlgebraGenerator.java
+++ b/algebra/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/RelationalAlgebraGenerator.java
@@ -57,6 +57,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.EnumSet;
 
+import org.apache.calcite.runtime.GeoFunctions;
+
 /**
  * <h1>Generate Relational Algebra</h1>
  * The purpose of this class is to hold the planner, the program, and the
@@ -101,7 +103,7 @@ public class RelationalAlgebraGenerator {
 
 			Properties info = new Properties();
 			info.setProperty("lex", "JAVA");
-			Connection connection = DriverManager.getConnection("jdbc:calcite:", info);
+			Connection connection = DriverManager.getConnection("jdbc:calcite:fun=spatial:", info);
 			CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class);
 			calciteConnection.setSchema(newSchema.getName());
 
@@ -118,6 +120,7 @@ public class RelationalAlgebraGenerator {
 			List<SqlOperatorTable> sqlOperatorTables = new ArrayList<>();
 			sqlOperatorTables.add(SqlLibraryOperatorTableFactory.INSTANCE.getOperatorTable(
 				EnumSet.of(SqlLibrary.STANDARD, SqlLibrary.ORACLE, SqlLibrary.MYSQL)));
+			sqlOperatorTables.add(CalciteCatalogReader.operatorTable(GeoFunctions.class.getName()));
 			sqlOperatorTables.add(new CalciteCatalogReader(CalciteSchema.from(schema.getSubSchema(newSchema.getName())),
 				defaultSchema,
 				new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT),


### PR DESCRIPTION
This PR enables support on Calcite spatial functions 

For now we don't have support (at engine level) for these spatial operators, but some of them work, like:

```
"SELECT col_a from geometry_table where ST_Distance(ST_MakePoint(125.2, 22.5), ST_MakePoint(2.0, 12.3)) > 100.2"
"SELECT ST_X(ST_MakePoint(125.22, 22.5)) from geometry_table"
"SELECT ST_Distance(ST_MakePoint(125.22, 22.5), ST_MakePoint(2.0, 12.3)) AS DISTANCE from geometry_table"
"SELECT ST_AsText(ST_MakePoint(125.22, 22.5)) from geometry_table"
"SELECT ST_AsWKT(ST_MakePoint(125.22, 22.5)) from geometry_table"
"SELECT ST_GeometryType(ST_MakePoint(125.22, 22.5)) from geometry_table"
"SELECT ST_GeometryType(ST_PointFromText('POINT (125 22)')) from geometry_table"
"SELECT ST_GeometryType(ST_LineFromText('LINESTRING (125 22, 100 50, 80 52)')) from geometry_table"
"SELECT ST_GeometryType(ST_PolyFromText('POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))')) from geometry_table"
"SELECT ST_GeometryType(ST_MakeLine(ST_MakePoint(125.22, 22.5), ST_MakePoint(15.72, 21.5))) from geometry_table"
```

I think some of the more useful operator that we want to enable primarily are: 
```
ST_PointFromText()
ST_MakePoint()
ST_Distance()
ST_PointFromText()
ST_AsText()
```

we want to consider a new `Geom` dtype in order to support these spatial operators. 