### PR TITLE
[REVIEW] Fixes to initialization and adding unique ids to comms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - #1267 Added retrys to comms, fixed deadlocks in executor and order by. Improved logging and error management. Caches have names. Improved Joins
 - #1239 Reducing Memory pressure by moving shuffle data to cpu before transmission
 - #1278 Fix race conditions with UCX
+- #1286 Fixes to initialization and adding unique ids to comms 
 
 ## Bug Fixes
 - #1249 Fix compilation with cuda 11

--- a/engine/src/communication/CommunicationInterface/messageReceiver.cpp
+++ b/engine/src/communication/CommunicationInterface/messageReceiver.cpp
@@ -27,7 +27,8 @@ message_receiver::message_receiver(const std::map<std::string, comm::node>& node
     comms_logger = spdlog::get("input_comms");
     auto destinations = _metadata.get_values()[ral::cache::WORKER_IDS_METADATA_LABEL];
 
-    comms_logger->info("{ral_id}|{query_id}|{kernel_id}|{dest_ral_id}|{dest_ral_count}|{dest_cache_id}|{message_id}|{phase}",
+    comms_logger->info("{unique_id}|{ral_id}|{query_id}|{kernel_id}|{dest_ral_id}|{dest_ral_count}|{dest_cache_id}|{message_id}|{phase}",
+    "unique_id"_a=_metadata.get_values()[ral::cache::UNIQUE_MESSAGE_ID],
     "ral_id"_a=_metadata.get_values()[ral::cache::RAL_ID_METADATA_LABEL],
     "query_id"_a=_metadata.get_values()[ral::cache::QUERY_ID_METADATA_LABEL],
     "kernel_id"_a=_metadata.get_values()[ral::cache::KERNEL_ID_METADATA_LABEL],
@@ -92,7 +93,8 @@ void message_receiver::finish(cudaStream_t stream) {
     comms_logger = spdlog::get("input_comms");
     auto destinations = _metadata.get_values()[ral::cache::WORKER_IDS_METADATA_LABEL];
 
-    comms_logger->info("{ral_id}|{query_id}|{kernel_id}|{dest_ral_id}|{dest_ral_count}|{dest_cache_id}|{message_id}|{phase}",
+    comms_logger->info("{unique_id}|{ral_id}|{query_id}|{kernel_id}|{dest_ral_id}|{dest_ral_count}|{dest_cache_id}|{message_id}|{phase}",
+    "unique_id"_a=_metadata.get_values()[ral::cache::UNIQUE_MESSAGE_ID],
     "ral_id"_a=_metadata.get_values()[ral::cache::RAL_ID_METADATA_LABEL],
     "query_id"_a=_metadata.get_values()[ral::cache::QUERY_ID_METADATA_LABEL],
     "kernel_id"_a=_metadata.get_values()[ral::cache::KERNEL_ID_METADATA_LABEL],

--- a/engine/src/communication/CommunicationInterface/messageSender.cpp
+++ b/engine/src/communication/CommunicationInterface/messageSender.cpp
@@ -85,7 +85,7 @@ void message_sender::run_polling() {
 						auto metadata = cpu_cache_data->getMetadata();
 
 						auto destinations_str = metadata.get_values()[ral::cache::WORKER_IDS_METADATA_LABEL];
-						comms_logger->info("{unique_id}|{ral_id}|{query_id}|{kernel_id}|{dest_ral_id}|{dest_ral_count}|{dest_cache_id}|{message_id}",
+						comms_logger->info("{unique_id}|{ral_id}|{query_id}|{kernel_id}|{dest_ral_id}|{dest_ral_count}|{dest_cache_id}|{message_id}|{phase}",
 							"unique_id"_a=metadata.get_values()[ral::cache::UNIQUE_MESSAGE_ID],
 							"ral_id"_a=ral_id,
 							"query_id"_a=metadata.get_values()[ral::cache::QUERY_ID_METADATA_LABEL],
@@ -93,7 +93,8 @@ void message_sender::run_polling() {
 							"dest_ral_id"_a=destinations_str, //false
 							"dest_ral_count"_a=std::count(destinations_str.begin(), destinations_str.end(), ',') + 1,
 							"dest_cache_id"_a=metadata.get_values()[ral::cache::CACHE_ID_METADATA_LABEL],
-							"message_id"_a=metadata.get_values()[ral::cache::MESSAGE_ID]);
+							"message_id"_a=metadata.get_values()[ral::cache::MESSAGE_ID],
+							"phase"_a="begin");
 
 						std::vector<std::size_t> buffer_sizes;
 						std::vector<const char *> raw_buffers;
@@ -145,6 +146,16 @@ void message_sender::run_polling() {
 							transport->send(raw_buffers[i], buffer_sizes[i]);
 						}
 						transport->wait_until_complete();  // ensures that the message has been sent before returning the thread to the pool
+						comms_logger->info("{unique_id}|{ral_id}|{query_id}|{kernel_id}|{dest_ral_id}|{dest_ral_count}|{dest_cache_id}|{message_id}|{phase}",
+							"unique_id"_a=metadata.get_values()[ral::cache::UNIQUE_MESSAGE_ID],
+							"ral_id"_a=ral_id,
+							"query_id"_a=metadata.get_values()[ral::cache::QUERY_ID_METADATA_LABEL],
+							"kernel_id"_a=metadata.get_values()[ral::cache::KERNEL_ID_METADATA_LABEL],
+							"dest_ral_id"_a=destinations_str, //false
+							"dest_ral_count"_a=std::count(destinations_str.begin(), destinations_str.end(), ',') + 1,
+							"dest_cache_id"_a=metadata.get_values()[ral::cache::CACHE_ID_METADATA_LABEL],
+							"message_id"_a=metadata.get_values()[ral::cache::MESSAGE_ID],
+							"phase"_a="end");
 					} catch(const std::exception & e) {
 						auto logger = spdlog::get("batch_logger");
 						if (logger){

--- a/engine/src/communication/CommunicationInterface/messageSender.cpp
+++ b/engine/src/communication/CommunicationInterface/messageSender.cpp
@@ -85,7 +85,8 @@ void message_sender::run_polling() {
 						auto metadata = cpu_cache_data->getMetadata();
 
 						auto destinations_str = metadata.get_values()[ral::cache::WORKER_IDS_METADATA_LABEL];
-						comms_logger->info("{ral_id}|{query_id}|{kernel_id}|{dest_ral_id}|{dest_ral_count}|{dest_cache_id}|{message_id}",
+						comms_logger->info("{unique_id}|{ral_id}|{query_id}|{kernel_id}|{dest_ral_id}|{dest_ral_count}|{dest_cache_id}|{message_id}",
+							"unique_id"_a=metadata.get_values()[ral::cache::UNIQUE_MESSAGE_ID],
 							"ral_id"_a=ral_id,
 							"query_id"_a=metadata.get_values()[ral::cache::QUERY_ID_METADATA_LABEL],
 							"kernel_id"_a=metadata.get_values()[ral::cache::KERNEL_ID_METADATA_LABEL],

--- a/engine/src/cython/engine.cpp
+++ b/engine/src/cython/engine.cpp
@@ -170,6 +170,7 @@ std::shared_ptr<ral::cache::graph> runGenerateGraph(uint32_t masterIndex,
 
 std::unique_ptr<PartitionedResultSet> runExecuteGraph(std::shared_ptr<ral::cache::graph> graph, int32_t ctx_token) {
 	// Execute query
+
 	std::vector<std::unique_ptr<ral::frame::BlazingTable>> frames;
 	frames = execute_graph(graph);
 
@@ -188,9 +189,6 @@ std::unique_ptr<PartitionedResultSet> runExecuteGraph(std::shared_ptr<ral::cache
 	result->skipdata_analysis_fail = false;
 
 	comm::graphs_info::getInstance().deregister_graph(ctx_token);
-	spdlog::get("batch_logger")->info("{allocation_count}|{total_buffer_count}", 
-			"allocation_count"_a=blazingdb::transport::io::getPinnedBufferProvider().get_allocated_buffers(),
-			"total_buffer_count"_a=blazingdb::transport::io::getPinnedBufferProvider().get_total_buffers());
 	return result;
 }
 /*

--- a/engine/src/cython/initialize.cpp
+++ b/engine/src/cython/initialize.cpp
@@ -884,8 +884,6 @@ std::pair<std::pair<std::shared_ptr<CacheMachine>,std::shared_ptr<CacheMachine> 
 	&release_number 
 	);
 
-	std::cout<<"UCX version:"<<major_version<<"."<<minor_version<<"."<<release_number<<std::endl;
-
 	ral::execution::executor::init_executor(executor_threads, processing_memory_limit_threshold);
 	return std::make_pair(output_input_caches, ralCommunicationPort);	
 }

--- a/engine/src/cython/initialize.cpp
+++ b/engine/src/cython/initialize.cpp
@@ -130,6 +130,11 @@ void create_logger(std::string fileName,
 	std::size_t max_size_logging,
 	bool simple_log=true) {
 
+	std::shared_ptr<spdlog::logger> existing_logger = spdlog::get(loggingName);
+	if (existing_logger){ // if logger already exists, dont initialize again
+		return;
+	}
+
 	auto stdout_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
 	stdout_sink->set_pattern("[%T.%e] [%^%l%$] %v");
 	stdout_sink->set_level(spdlog::level::err);
@@ -515,6 +520,11 @@ ucp_ep_h CreateUcpEp(ucp_worker_h ucp_worker,
   return ucp_ep;
 }
 
+
+
+std::mutex initialize_lock;
+bool initialized = false;
+
 //=============================================================================
 
 /**
@@ -533,6 +543,8 @@ std::pair<std::pair<std::shared_ptr<CacheMachine>,std::shared_ptr<CacheMachine> 
 	std::size_t initial_pool_size,
 	std::size_t maximum_pool_size,
 	bool enable_logging) {
+
+	std::lock_guard<std::mutex> init_lock(initialize_lock);
 
 	float device_mem_resouce_consumption_thresh = 0.6;
 	auto config_it = config_options.find("BLAZING_DEVICE_MEM_CONSUMPTION_THRESHOLD");
@@ -606,11 +618,6 @@ std::pair<std::pair<std::shared_ptr<CacheMachine>,std::shared_ptr<CacheMachine> 
 	// Init AWS S3 ... TODO see if we need to call shutdown and avoid leaks from s3 percy
 	BlazingContext::getInstance()->initExternalSystems();
 
-	// spdlog batch logger
-	spdlog::shutdown();
-
-	spdlog::init_thread_pool(8192, 1);
-
 	int executor_threads = 10;
 	auto exec_it = config_options.find("EXECUTOR_THREADS");
 	if (exec_it != config_options.end()){
@@ -636,64 +643,72 @@ std::pair<std::pair<std::shared_ptr<CacheMachine>,std::shared_ptr<CacheMachine> 
 		max_size_logging = std::stoi(config_options["LOGGING_MAX_SIZE_PER_FILE"]);
 	}
 
-	std::string batchLoggerFileName = logging_dir + "/RAL." + std::to_string(ralId) + ".log";
-	create_logger(batchLoggerFileName, "batch_logger", ralId, flush_level, logger_level_wanted, max_size_logging, false);
+	if (!initialized){
 
-	std::string outputCommunicationLoggerFileName = logging_dir + "/output_comms." + std::to_string(ralId) + ".log";
-	create_logger(outputCommunicationLoggerFileName, "output_comms", ralId, flush_level, logger_level_wanted, max_size_logging);
+		// spdlog batch logger
+		spdlog::shutdown();
 
-	std::string inputCommunicationLoggerFileName = logging_dir + "/input_comms." + std::to_string(ralId) + ".log";
-	create_logger(inputCommunicationLoggerFileName, "input_comms", ralId, flush_level, logger_level_wanted, max_size_logging);
+		spdlog::init_thread_pool(8192, 1);
+
+		std::string batchLoggerFileName = logging_dir + "/RAL." + std::to_string(ralId) + ".log";
+		create_logger(batchLoggerFileName, "batch_logger", ralId, flush_level, logger_level_wanted, max_size_logging, false);
+
+		std::string outputCommunicationLoggerFileName = logging_dir + "/output_comms." + std::to_string(ralId) + ".log";
+		create_logger(outputCommunicationLoggerFileName, "output_comms", ralId, flush_level, logger_level_wanted, max_size_logging);
+
+		std::string inputCommunicationLoggerFileName = logging_dir + "/input_comms." + std::to_string(ralId) + ".log";
+		create_logger(inputCommunicationLoggerFileName, "input_comms", ralId, flush_level, logger_level_wanted, max_size_logging);
 
 
-	std::string queriesFileName = logging_dir + "/bsql_queries." + std::to_string(ralId) + ".log";
-	bool existsQueriesFileName = std::ifstream(queriesFileName).good();
-	create_logger(queriesFileName, "queries_logger", ralId, flush_level, logger_level_wanted, max_size_logging);
+		std::string queriesFileName = logging_dir + "/bsql_queries." + std::to_string(ralId) + ".log";
+		bool existsQueriesFileName = std::ifstream(queriesFileName).good();
+		create_logger(queriesFileName, "queries_logger", ralId, flush_level, logger_level_wanted, max_size_logging);
 
-	std::string kernelsFileName = logging_dir + "/bsql_kernels." + std::to_string(ralId) + ".log";
-	bool existsKernelsFileName = std::ifstream(kernelsFileName).good();
-	create_logger(kernelsFileName, "kernels_logger", ralId, flush_level, logger_level_wanted, max_size_logging);
+		std::string kernelsFileName = logging_dir + "/bsql_kernels." + std::to_string(ralId) + ".log";
+		bool existsKernelsFileName = std::ifstream(kernelsFileName).good();
+		create_logger(kernelsFileName, "kernels_logger", ralId, flush_level, logger_level_wanted, max_size_logging);
 
-	std::string kernelsEdgesFileName = logging_dir + "/bsql_kernels_edges." + std::to_string(ralId) + ".log";
-	bool existsKernelsEdgesFileName = std::ifstream(kernelsEdgesFileName).good();
-	create_logger(kernelsEdgesFileName, "kernels_edges_logger", ralId, flush_level, logger_level_wanted, max_size_logging);
+		std::string kernelsEdgesFileName = logging_dir + "/bsql_kernels_edges." + std::to_string(ralId) + ".log";
+		bool existsKernelsEdgesFileName = std::ifstream(kernelsEdgesFileName).good();
+		create_logger(kernelsEdgesFileName, "kernels_edges_logger", ralId, flush_level, logger_level_wanted, max_size_logging);
 
-	std::string kernelEventsFileName = logging_dir + "/bsql_kernel_events." + std::to_string(ralId) + ".log";
-	bool existsKernelEventsFileName = std::ifstream(kernelEventsFileName).good();
-	create_logger(kernelEventsFileName, "events_logger", ralId, flush_level, logger_level_wanted, max_size_logging);
+		std::string kernelEventsFileName = logging_dir + "/bsql_kernel_events." + std::to_string(ralId) + ".log";
+		bool existsKernelEventsFileName = std::ifstream(kernelEventsFileName).good();
+		create_logger(kernelEventsFileName, "events_logger", ralId, flush_level, logger_level_wanted, max_size_logging);
 
-	std::string cacheEventsFileName = logging_dir + "/bsql_cache_events." + std::to_string(ralId) + ".log";
-	bool existsCacheEventsFileName = std::ifstream(cacheEventsFileName).good();
-	create_logger(cacheEventsFileName, "cache_events_logger", ralId, flush_level, logger_level_wanted, max_size_logging);
+		std::string cacheEventsFileName = logging_dir + "/bsql_cache_events." + std::to_string(ralId) + ".log";
+		bool existsCacheEventsFileName = std::ifstream(cacheEventsFileName).good();
+		create_logger(cacheEventsFileName, "cache_events_logger", ralId, flush_level, logger_level_wanted, max_size_logging);
 
-	//Logger Headers
-	if(!existsQueriesFileName) {
-		std::shared_ptr<spdlog::logger> queries_logger = spdlog::get("queries_logger");
-		queries_logger->info("ral_id|query_id|start_time|plan|query");
-	}
+		//Logger Headers
+		if(!existsQueriesFileName) {
+			std::shared_ptr<spdlog::logger> queries_logger = spdlog::get("queries_logger");
+			queries_logger->info("ral_id|query_id|start_time|plan|query");
+		}
 
-	if(!existsKernelsFileName) {
-		std::shared_ptr<spdlog::logger> kernels_logger = spdlog::get("kernels_logger");
-		kernels_logger->info("ral_id|query_id|kernel_id|is_kernel|kernel_type");
-	}
+		if(!existsKernelsFileName) {
+			std::shared_ptr<spdlog::logger> kernels_logger = spdlog::get("kernels_logger");
+			kernels_logger->info("ral_id|query_id|kernel_id|is_kernel|kernel_type");
+		}
 
-	if(!existsKernelsEdgesFileName) {
-		std::shared_ptr<spdlog::logger> kernels_edges_logger = spdlog::get("kernels_edges_logger");
-		kernels_edges_logger->info("ral_id|query_id|source|sink");
-	}
+		if(!existsKernelsEdgesFileName) {
+			std::shared_ptr<spdlog::logger> kernels_edges_logger = spdlog::get("kernels_edges_logger");
+			kernels_edges_logger->info("ral_id|query_id|source|sink");
+		}
 
-	if(!existsKernelEventsFileName) {
-		std::shared_ptr<spdlog::logger> events_logger = spdlog::get("events_logger");
-		events_logger->info("ral_id|query_id|kernel_id|input_num_rows|input_num_bytes|output_num_rows|output_num_bytes|event_type|timestamp_begin|timestamp_end");
-	}
+		if(!existsKernelEventsFileName) {
+			std::shared_ptr<spdlog::logger> events_logger = spdlog::get("events_logger");
+			events_logger->info("ral_id|query_id|kernel_id|input_num_rows|input_num_bytes|output_num_rows|output_num_bytes|event_type|timestamp_begin|timestamp_end");
+		}
 
-	if(!existsCacheEventsFileName) {
-		std::shared_ptr<spdlog::logger> cache_events_logger = spdlog::get("cache_events_logger");
-		cache_events_logger->info("ral_id|query_id|source|sink|num_rows|num_bytes|event_type|timestamp_begin|timestamp_end");
-	}
+		if(!existsCacheEventsFileName) {
+			std::shared_ptr<spdlog::logger> cache_events_logger = spdlog::get("cache_events_logger");
+			cache_events_logger->info("ral_id|query_id|source|sink|num_rows|num_bytes|event_type|timestamp_begin|timestamp_end");
+		}
+
+	} 
 
 	std::shared_ptr<spdlog::logger> logger = spdlog::get("batch_logger");
-
 	if (logging_directory_missing){
 		logger->error("|||{info}|||||","info"_a="BLAZING_LOGGING_DIRECTORY not found. It was not created.");
 	}
@@ -876,15 +891,8 @@ std::pair<std::pair<std::shared_ptr<CacheMachine>,std::shared_ptr<CacheMachine> 
 		processing_memory_limit_threshold = std::stod(config_options["BLAZING_PROCESSING_DEVICE_MEM_CONSUMPTION_THRESHOLD"]);
 	}
 
-	unsigned major_version;
-	unsigned minor_version;
-	unsigned release_number;
-	ucp_get_version	(&major_version,
-	&minor_version,
-	&release_number 
-	);
-
 	ral::execution::executor::init_executor(executor_threads, processing_memory_limit_threshold);
+	initialized = true;
 	return std::make_pair(output_input_caches, ralCommunicationPort);	
 }
 

--- a/engine/src/execution_graph/logic_controllers/BatchProcessing.cpp
+++ b/engine/src/execution_graph/logic_controllers/BatchProcessing.cpp
@@ -171,47 +171,46 @@ kstatus TableScan::run() {
     //if its empty we can just add it to the cache without scheduling
     if (!provider->has_next()) {
         this->add_to_output_cache(std::move(schema.makeEmptyBlazingTable(projections)));
-        return kstatus::proceed;
+    } else {
+
+        while(provider->has_next()) {
+            //retrieve the file handle but do not open the file
+            //this will allow us to prevent from having too many open file handles by being
+            //able to limit the number of file tasks
+            auto handle = provider->get_next(true);
+            auto file_schema = schema.fileSchema(file_index);
+            auto row_group_ids = schema.get_rowgroup_ids(file_index);
+            //this is the part where we make the task now
+            std::unique_ptr<ral::cache::CacheData> input =
+                std::make_unique<ral::cache::CacheDataIO>(handle,parser,schema,file_schema,row_group_ids,projections);
+            std::vector<std::unique_ptr<ral::cache::CacheData> > inputs;
+            inputs.push_back(std::move(input));
+            auto output_cache = this->output_cache();
+
+            ral::execution::executor::get_instance()->add_task(
+                    std::move(inputs),
+                    output_cache,
+                    this);
+
+            /*if (this->has_limit_ && output_cache->get_num_rows_added() >= this->limit_rows_) {
+            //	break;
+            }*/
+            file_index++;
+        }
+
+        logger->debug("{query_id}|{step}|{substep}|{info}|{duration}|kernel_id|{kernel_id}||",
+                                    "query_id"_a=context->getContextToken(),
+                                    "step"_a=context->getQueryStep(),
+                                    "substep"_a=context->getQuerySubstep(),
+                                    "info"_a="TableScan Kernel tasks created",
+                                    "duration"_a=timer.elapsed_time(),
+                                    "kernel_id"_a=this->get_id());
+
+        std::unique_lock<std::mutex> lock(kernel_mutex);
+        kernel_cv.wait(lock,[this]{
+            return this->tasks.empty();
+        });
     }
-
-    while(provider->has_next()) {
-        //retrieve the file handle but do not open the file
-        //this will allow us to prevent from having too many open file handles by being
-        //able to limit the number of file tasks
-        auto handle = provider->get_next(true);
-        auto file_schema = schema.fileSchema(file_index);
-        auto row_group_ids = schema.get_rowgroup_ids(file_index);
-        //this is the part where we make the task now
-        std::unique_ptr<ral::cache::CacheData> input =
-            std::make_unique<ral::cache::CacheDataIO>(handle,parser,schema,file_schema,row_group_ids,projections);
-        std::vector<std::unique_ptr<ral::cache::CacheData> > inputs;
-        inputs.push_back(std::move(input));
-        auto output_cache = this->output_cache();
-
-        ral::execution::executor::get_instance()->add_task(
-                std::move(inputs),
-                output_cache,
-                this);
-
-        /*if (this->has_limit_ && output_cache->get_num_rows_added() >= this->limit_rows_) {
-        //	break;
-        }*/
-        file_index++;
-    }
-
-    logger->debug("{query_id}|{step}|{substep}|{info}|{duration}|kernel_id|{kernel_id}||",
-                                "query_id"_a=context->getContextToken(),
-                                "step"_a=context->getQueryStep(),
-                                "substep"_a=context->getQuerySubstep(),
-                                "info"_a="TableScan Kernel tasks created",
-                                "duration"_a=timer.elapsed_time(),
-                                "kernel_id"_a=this->get_id());
-
-    std::unique_lock<std::mutex> lock(kernel_mutex);
-    kernel_cv.wait(lock,[this]{
-        return this->tasks.empty();
-    });
-
     logger->debug("{query_id}|{step}|{substep}|{info}|{duration}|kernel_id|{kernel_id}||",
                                 "query_id"_a=context->getContextToken(),
                                 "step"_a=context->getQueryStep(),

--- a/engine/src/execution_graph/logic_controllers/CacheMachine.h
+++ b/engine/src/execution_graph/logic_controllers/CacheMachine.h
@@ -54,6 +54,7 @@ const std::string JOIN_RIGHT_BYTES_METADATA_LABEL = "join_right_bytes_metadata_l
 const std::string AVG_BYTES_PER_ROW_METADATA_LABEL = "avg_bytes_per_row"; /** < A message metadata field that indicates the average of bytes per row. */
 const std::string MESSAGE_ID = "message_id"; /**< A message metadata field that indicates the id of a message. Not all messages have an id. Any message that has add_to_specific_cache == false MUST have a message id. */
 const std::string PARTITION_COUNT = "partition_count"; /**< A message metadata field that indicates the number of partitions a kernel processed.  */
+const std::string UNIQUE_MESSAGE_ID = "unique_message_id"; /**< A message metadata field that indicates the unique id of a message. */
 
 const int CACHE_LEVEL_AUTO = -1;
 const int CACHE_LEVEL_GPU = 0;

--- a/engine/src/execution_graph/logic_controllers/taskflow/distributing_kernel.cpp
+++ b/engine/src/execution_graph/logic_controllers/taskflow/distributing_kernel.cpp
@@ -25,6 +25,8 @@ void distributing_kernel::set_number_of_message_trackers(std::size_t num_message
     messages_to_wait_for.resize(num_message_trackers);
 }
 
+std::atomic<uint32_t> unique_message_id(std::rand());
+
 void distributing_kernel::send_message(std::unique_ptr<ral::frame::BlazingTable> table,
         bool specific_cache,
         std::string cache_id,
@@ -51,6 +53,7 @@ void distributing_kernel::send_message(std::unique_ptr<ral::frame::BlazingTable>
     metadata.add_value(ral::cache::CACHE_ID_METADATA_LABEL, cache_id);
     metadata.add_value(ral::cache::SENDER_WORKER_ID_METADATA_LABEL, node.id());
     metadata.add_value(ral::cache::WORKER_IDS_METADATA_LABEL, worker_ids_metadata);
+    metadata.add_value(ral::cache::UNIQUE_MESSAGE_ID, std::to_string(unique_message_id.fetch_add(1)));
 
     const std::string MESSAGE_ID_CONTENT = metadata.get_values()[ral::cache::QUERY_ID_METADATA_LABEL] + "_" +
                                            metadata.get_values()[ral::cache::KERNEL_ID_METADATA_LABEL] + "_" +

--- a/engine/src/execution_graph/logic_controllers/taskflow/executor.cpp
+++ b/engine/src/execution_graph/logic_controllers/taskflow/executor.cpp
@@ -72,7 +72,7 @@ std::size_t task::task_memory_needed() {
 void task::run(cudaStream_t stream, executor * executor){
     try{
         kernel->process(inputs,output,stream,args);
-        complete();
+        complete();        
     }catch(rmm::bad_alloc e){
 
         auto logger = spdlog::get("batch_logger");

--- a/engine/tests/communication/message_send_receive.cpp
+++ b/engine/tests/communication/message_send_receive.cpp
@@ -29,6 +29,8 @@
 #include <netdb.h>
 #include <pthread.h> /* pthread_self */
 #include <thread>
+#include <stdio.h> 
+#include <unistd.h> 
 
 #include <spdlog/spdlog.h>
 #include <spdlog/async.h>
@@ -409,7 +411,7 @@ std::shared_ptr<blazingdb::manager::Context> make_context() {
 	std::string logicalPlan;
 	std::map<std::string, std::string> config_options;
 
-	return std::make_shared<Context>(query_id, nodes, master_node, logicalPlan, config_options);
+	return std::make_shared<blazingdb::manager::Context>(query_id, nodes, master_node, logicalPlan, config_options);
 }
 
 std::shared_ptr<ral::cache::graph> create_graph(){
@@ -754,7 +756,7 @@ void SenderCall(const UcpWorkerAddress &peerUcpWorkerAddress,
   std::map<std::string, comm::node> nodes_info_map;
   nodes_info_map.emplace("server", comm::node(1, "server", ucp_ep, ucp_worker));
 
-  auto output_cache = std::make_shared<ral::cache::CacheMachine>(nullptr);
+  auto output_cache = std::make_shared<ral::cache::CacheMachine>(nullptr, "output");
 
   for (size_t i = 0; i < 30; i++)
   {
@@ -780,8 +782,8 @@ void ReceiverCall(const UcpWorkerAddress &peerUcpWorkerAddress,
   std::map<std::string, comm::node> nodes_info_map;
   nodes_info_map.emplace("client", comm::node(0, "client", ucp_ep, ucp_worker));
 
-  auto output_cache = std::make_shared<ral::cache::CacheMachine>(nullptr);
-  auto input_cache = std::make_shared<ral::cache::CacheMachine>(nullptr);
+  auto output_cache = std::make_shared<ral::cache::CacheMachine>(nullptr, "output");
+  auto input_cache = std::make_shared<ral::cache::CacheMachine>(nullptr, "input");
 
   auto graph = create_graph();
   graph->set_input_and_output_caches(input_cache, output_cache);
@@ -804,38 +806,39 @@ void ReceiverCall(const UcpWorkerAddress &peerUcpWorkerAddress,
   }
 }
 
-// struct MessageSendReceiveTest : public BlazingUnitTest {
-//   MessageSendReceiveTest() {}
+struct MessageSendReceiveTest : public BlazingUnitTest {
+  MessageSendReceiveTest() {}
 
-//   ~MessageSendReceiveTest() {}
-// };
+  ~MessageSendReceiveTest() {}
+};
 
-// TEST_F(MessageSendReceiveTest, send_receive_test) {
-//   auto thread = std::thread([]{
-//     ::Run(SenderCall, AddressExchanger::MakeForSender(exchangingPort));
-//   });
-// // std::this_thread::sleep_for(std::chrono::seconds(2));
-//   auto thread_2 = std::thread([]{
-//     ::Run(ReceiverCall, AddressExchanger::MakeForReceiver(exchangingPort, "localhost"));
-//   });
-//   thread.join();
-//   thread_2.join();
-// }
+TEST_F(MessageSendReceiveTest, send_receive_test) {
 
-int main(int argc, char *argv[]){
-	create_test_logger("batch_logger");
-	create_test_logger("queries_logger");
-	create_test_logger("kernels_logger");
-	create_test_logger("kernels_edges_logger");
-	create_test_logger("events_logger");
-	create_test_logger("cache_events_logger");
+  int pid = fork();
 
-  if (argc < 2) {
+  if (pid == 0){
     ::Run(SenderCall, AddressExchanger::MakeForSender(exchangingPort));
-  }else {
+  } else if (pid > 0) {
     ::Run(ReceiverCall, AddressExchanger::MakeForReceiver(exchangingPort, "localhost"));
-  };
-
-  std::cout << ">>>> END UNIT TEST"<<std::endl;
-  return 0;
+  } else {
+    std::cout<<"error forking"<<std::endl;
+  }
 }
+
+// int main(int argc, char *argv[]){
+// 	create_test_logger("batch_logger");
+// 	create_test_logger("queries_logger");
+// 	create_test_logger("kernels_logger");
+// 	create_test_logger("kernels_edges_logger");
+// 	create_test_logger("events_logger");
+// 	create_test_logger("cache_events_logger");
+
+//   if (argc < 2) {
+//     ::Run(SenderCall, AddressExchanger::MakeForSender(exchangingPort));
+//   }else {
+//     ::Run(ReceiverCall, AddressExchanger::MakeForReceiver(exchangingPort, "localhost"));
+//   };
+
+//   std::cout << ">>>> END UNIT TEST"<<std::endl;
+//   return 0;
+// }

--- a/pyblazing/pyblazing/apiv2/comms.py
+++ b/pyblazing/pyblazing/apiv2/comms.py
@@ -43,7 +43,5 @@ def get_communication_port(network_interface):
 
 def listen(client, network_interface=""):
     worker_id_maps = client.run(get_communication_port, network_interface, wait=True)
-    print("worker_id_maps")
-    print(worker_id_maps)
     client.run(set_id_mappings_on_worker, worker_id_maps, wait=True)
     return worker_id_maps

--- a/pyblazing/pyblazing/apiv2/comms.py
+++ b/pyblazing/pyblazing/apiv2/comms.py
@@ -29,7 +29,7 @@ def checkSocket(socketNum):
         else:
             # something else raised the socket.error exception
             print("ERROR: Something happened when checking socket " + str(socketNum))
-    
+
     return socket_free
 
 

--- a/pyblazing/pyblazing/apiv2/comms.py
+++ b/pyblazing/pyblazing/apiv2/comms.py
@@ -22,13 +22,14 @@ def checkSocket(socketNum):
     try:
         s.bind(("127.0.0.1", socketNum))
         socket_free = True
+        s.close()
     except socket.error as e:
         if e.errno == errno.EADDRINUSE:
             socket_free = False
         else:
             # something else raised the socket.error exception
             print("ERROR: Something happened when checking socket " + str(socketNum))
-    s.close()
+    
     return socket_free
 
 
@@ -42,5 +43,7 @@ def get_communication_port(network_interface):
 
 def listen(client, network_interface=""):
     worker_id_maps = client.run(get_communication_port, network_interface, wait=True)
+    print("worker_id_maps")
+    print(worker_id_maps)
     client.run(set_id_mappings_on_worker, worker_id_maps, wait=True)
     return worker_id_maps

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -3026,7 +3026,7 @@ class BlazingContext(object):
                     )
                     i = i + 1
                 graph_futures = self.dask_client.gather(graph_futures)
-                
+
                 dask_futures = []
                 for node in self.nodes:
                     worker = node["worker"]

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -331,13 +331,14 @@ def generateGraphs(
         )
         graph.set_input_and_output_caches(worker.input_cache, worker.output_cache)
     except Exception as e:
+        logger = get_blazing_logger(True)
+        logger.error("runGenerateGraphCaller failed")
         raise e
 
     with worker._lock:
         if not hasattr(worker, "query_graphs"):
             worker.query_graphs = {}
-
-    worker.query_graphs[ctxToken] = graph
+        worker.query_graphs[ctxToken] = graph
 
 
 def executeGraph(ctxToken):
@@ -1147,7 +1148,6 @@ def load_config_options_from_env(user_config_options: dict):
         "MAX_JOIN_SCATTER_MEM_OVERHEAD": 500000000,
         "MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE": 8,
         "NUM_BYTES_PER_ORDER_BY_PARTITION": 400000000,
-        "TABLE_SCAN_KERNEL_NUM_THREADS": 4,
         "MAX_DATA_LOAD_CONCAT_CACHE_BYTE_SIZE": 400000000,
         "FLOW_CONTROL_BYTES_THRESHOLD": 18446744073709551615,  # see https://en.cppreference.com/w/cpp/types/numeric_limits/max
         "MAX_ORDER_BY_SAMPLES_PER_NODE": 10000,
@@ -1267,9 +1267,6 @@ class BlazingContext(object):
                     MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE will be enforced over
                     this parameter.
                     default: 400000000
-            TABLE_SCAN_KERNEL_NUM_THREADS: The number of threads used in the
-                    TableScan & BindableTableScan kernels for reading batches
-                    default: 4
             MAX_DATA_LOAD_CONCAT_CACHE_BYTE_SIZE : The max size in bytes to
                     concatenate the batches read from the scan kernels
                     default: 400000000
@@ -3029,7 +3026,7 @@ class BlazingContext(object):
                     )
                     i = i + 1
                 graph_futures = self.dask_client.gather(graph_futures)
-
+                
                 dask_futures = []
                 for node in self.nodes:
                     worker = node["worker"]

--- a/tests/BlazingSQLTest/EndToEndTests/configOptionsTest.py
+++ b/tests/BlazingSQLTest/EndToEndTests/configOptionsTest.py
@@ -23,14 +23,12 @@ def main(dask_client, drill, spark, dir_data_file, bc, nRals):
     conf_opt_1 = {}
     conf_opt_1["JOIN_PARTITION_SIZE_THRESHOLD"] = 10
     conf_opt_1["MAX_DATA_LOAD_CONCAT_CACHE_BYTE_SIZE"] = 10
-    conf_opt_1["TABLE_SCAN_KERNEL_NUM_THREADS"] = 3
     conf_opt_1["MAX_KERNEL_RUN_THREADS"] = 5
 
     # conf_opt_2
     conf_opt_2 = {}
     conf_opt_2["JOIN_PARTITION_SIZE_THRESHOLD"] = 10
     conf_opt_2["MAX_DATA_LOAD_CONCAT_CACHE_BYTE_SIZE"] = 10
-    conf_opt_2["TABLE_SCAN_KERNEL_NUM_THREADS"] = 1
     conf_opt_2["MAX_KERNEL_RUN_THREADS"] = 1
 
     # conf_opt_3


### PR DESCRIPTION
This PR has a couple improvements:

Adds unique ids to comms messages so that they can be more uniquely identified, and also adds begin and end phases.
Fixed issues in initialization of logs when multiple BlazingContexts are getting created at the same time.

Also gets rid of `TABLE_SCAN_KERNEL_NUM_THREADS` which is no longer used