### PR TITLE
Fix JDK install for Power9

### DIFF
--- a/powerpc/build.sh
+++ b/powerpc/build.sh
@@ -687,12 +687,12 @@ echo "END UCX requirements"
 echo "BEGIN JAVA"
 cd $build_dir
 if [ ! -f ibm-java-sdk-8.0-6.11-ppc64le-archive.bin ]; then
-    wget http://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/8.0.6.11/linux/ppc64le/ibm-java-sdk-8.0-6.11-ppc64le-archive.bin
-    chmod +x ibm-java-sdk-8.0-6.11-ppc64le-archive.bin
-    ./ibm-java-sdk-8.0-6.11-ppc64le-archive.bin
+    wget http://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/11.0.10.0/linux/ppc64le/ibm-java-jdk_ppc64le_linux_11.0.10.0-archive.bin
+    chmod +x ibm-java-jdk_ppc64le_linux_11.0.10.0-archive.bin
+    ./ibm-java-jdk_ppc64le_linux_11.0.10.0-archive.bin
 fi
-export PATH=$PWD/ibm-java-ppc64le-80/bin:$PATH
-export JAVA_HOME=$PWD/ibm-java-ppc64le-80/jre
+export PATH=$PWD/ibm-java-ppc64le-110/jdk-11.0.10+9/bin:$PATH
+export JAVA_HOME=$PWD/ibm-java-ppc64le-110/jdk-11.0.10+9/lib/j9vm/libjvm.so
 echo "END JAVA"
 # END JAVA
 

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -75,7 +75,10 @@ if "JAVA_HOME" in os.environ:
 # NOTE felipe try first with CONDA_PREFIX/jre/lib/amd64/server/libjvm.so
 # (for older Java versions e.g. 8.x)
 java_home_path = os.environ[the_java_home]
-jvm_path = java_home_path + "/lib/" + machine_processor + "/server/libjvm.so"
+jvm_path = java_home_path
+
+if not os.path.isfile(jvm_path):
+    jvm_path = java_home_path + "/lib/" + machine_processor + "/server/libjvm.so"
 
 if not os.path.isfile(jvm_path):
     # NOTE felipe try a second time using CONDA_PREFIX/lib/server/


### PR DESCRIPTION
Update to a more recent version of the IBM Java SDK version 11 (the previous version was not available for download anymore and the build script failed).

Allow users to directly specify the path to `libjvm.so` in the `JAVA_HOME` environment variable, since the internal directory structure of the SDK has changed. Maybe it would make sense to make this the new documented default way, and eliminate the convoluted logic here
https://github.com/BlazingDB/blazingsql/blob/20f2fa94411c6a8b3557b8cc18b72d9220a2b07f/pyblazing/pyblazing/apiv2/context.py#L75-L95

