### PR TITLE
[WIP] Skip getting orc metadata for decimal type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@
 - #1300 Fixed issue when creating tables from a local dir relative path
 - #1312 Fix progress bar for jupyterlab
 - #1318 Disabled require acknowledge 
-
+- #1387 Skip getting orc metadata for decimal type
 
 # BlazingSQL 0.17.0 (December 10, 2020)
 

--- a/engine/src/io/data_parser/metadata/orc_metadata.cpp
+++ b/engine/src/io/data_parser/metadata/orc_metadata.cpp
@@ -136,9 +136,21 @@ void set_min_max(
 		auto max = type_stat->has_maximum() ? *type_stat->maximum() : std::numeric_limits<int32_t>::max();
 		minmax_metadata_table[col_index] = min;
 		minmax_metadata_table[col_index + 1] = max;
+	} else if (statistic.type() == cudf::io::statistics_type::DECIMAL) {
+		throw std::runtime_error("ERROR: currently not supported statistic type for DECIMAL in ORC set_min_max");
+	} else if (statistic.type() == cudf::io::statistics_type::BINARY) {
+		throw std::runtime_error("ERROR: currently not supported statistic type for BINARY in ORC set_min_max");
 	} else {
-		throw std::runtime_error("Invalid statistic type in set_min_max");
+		throw std::runtime_error("ERROR: not supported statistic type for NONE in ORC set_min_max");
 	}
+}
+
+bool is_decimal_or_empty_dtype(cudf::type_id type_id) {
+	if (type_id == cudf::type_id::DECIMAL32 || type_id == cudf::type_id::DECIMAL64 || type_id == cudf::type_id::EMPTY) {
+		return true;
+	}
+
+	return false;
 }
 
 std::unique_ptr<ral::frame::BlazingTable> get_minmax_metadata(
@@ -268,8 +280,10 @@ std::unique_ptr<ral::frame::BlazingTable> get_minmax_metadata(
 	std::size_t not_string_count = 0;
 	for (std::size_t index = 0; index < metadata_names.size(); index++) {
 		cudf::data_type dtype = metadata_dtypes[index];
-		// we need to handle `strings` in a different way
-		if (dtype == cudf::data_type{cudf::type_id::STRING}) {
+		if (is_decimal_or_empty_dtype(dtype.id())) {
+			continue;
+		} // we need to handle `strings` in a different way
+		else if (dtype == cudf::data_type{cudf::type_id::STRING}) {
 			std::vector<std::string> vector_str = get_all_str_values_in_the_same_col(minmax_string_metadata, string_count);
 			string_count++;
 			std::pair<std::vector<char>, std::vector<cudf::size_type>> result_pair = concat_strings(vector_str);


### PR DESCRIPTION
This PR is a temporary work around for #1385 but it will skip when dtype is `DECIMAL`. If the issue is not due to a `DECIMAL` dtype then it will throw a more descriptive message about the dtype that is causing the issue, 