### PR TITLE
[REVIEW] Feature/concat cache machine timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - #1344 Removed GPUCacheDataMetadata class
 - #1376 Fixing build due to some strings refactor in cudf, undoing the replace workaround
 - #1331 Added flag to enable null e2e testing
+- #1419 Added concat cache machine timeout 
 
 ## Bug Fixes
 - #1335 Fixing uninitialized var in orc metadata and handling the parseMetadata exceptions properly

--- a/engine/src/execution_graph/logic_controllers/CacheMachine.cpp
+++ b/engine/src/execution_graph/logic_controllers/CacheMachine.cpp
@@ -799,8 +799,8 @@ ConcatenatingCacheMachine::ConcatenatingCacheMachine(std::shared_ptr<Context> co
 	: CacheMachine(context, cache_machine_name) {}
 
 ConcatenatingCacheMachine::ConcatenatingCacheMachine(std::shared_ptr<Context> context,
-			std::size_t concat_cache_num_bytes, bool concat_all, std::string cache_machine_name)
-	: CacheMachine(context, cache_machine_name), concat_cache_num_bytes(concat_cache_num_bytes), concat_all(concat_all) {
+			std::size_t concat_cache_num_bytes, int num_bytes_timeout, bool concat_all, std::string cache_machine_name)
+	: CacheMachine(context, cache_machine_name), concat_cache_num_bytes(concat_cache_num_bytes), num_bytes_timeout(num_bytes_timeout), concat_all(concat_all) {
 
 	}
 
@@ -812,7 +812,7 @@ std::unique_ptr<ral::frame::BlazingTable> ConcatenatingCacheMachine::pullFromCac
 	if (concat_all){
 		waitingCache->wait_until_finished();
 	} else {
-		waitingCache->wait_until_num_bytes(this->concat_cache_num_bytes);
+		waitingCache->wait_until_num_bytes(this->concat_cache_num_bytes, this->num_bytes_timeout);
 	}
 
 	size_t total_bytes = 0;
@@ -821,7 +821,11 @@ std::unique_ptr<ral::frame::BlazingTable> ConcatenatingCacheMachine::pullFromCac
 	std::string message_id = "";
 
 	do {
-		message_data = waitingCache->pop_or_wait();
+		if (concat_all || waitingCache->has_next_now()){
+			message_data = waitingCache->pop_or_wait();
+		} else {
+			message_data = nullptr;
+		}
 		if (message_data == nullptr){
 			break;
 		}
@@ -927,7 +931,7 @@ std::unique_ptr<ral::cache::CacheData> ConcatenatingCacheMachine::pullCacheData(
 	if (concat_all){
 		waitingCache->wait_until_finished();
 	} else {
-		waitingCache->wait_until_num_bytes(this->concat_cache_num_bytes);		
+		waitingCache->wait_until_num_bytes(this->concat_cache_num_bytes, this->num_bytes_timeout);		
 	}
 
 	size_t total_bytes = 0;
@@ -936,7 +940,11 @@ std::unique_ptr<ral::cache::CacheData> ConcatenatingCacheMachine::pullCacheData(
 	std::string message_id;
 
 	do {
-		message_data = waitingCache->pop_or_wait();
+		if (concat_all || waitingCache->has_next_now()){
+			message_data = waitingCache->pop_or_wait();
+		} else {
+			message_data = nullptr;
+		}
 		if (message_data == nullptr){
 			break;
 		}

--- a/engine/src/execution_graph/logic_controllers/CacheMachine.h
+++ b/engine/src/execution_graph/logic_controllers/CacheMachine.h
@@ -180,7 +180,7 @@ public:
 	ConcatenatingCacheMachine(std::shared_ptr<Context> context, std::string cache_machine_name);
 
 	ConcatenatingCacheMachine(std::shared_ptr<Context> context,
-			std::size_t concat_cache_num_bytes, bool concat_all, std::string cache_machine_name);
+			std::size_t concat_cache_num_bytes, int num_bytes_timeout, bool concat_all, std::string cache_machine_name);
 
 	~ConcatenatingCacheMachine() = default;
 
@@ -198,6 +198,7 @@ public:
 
   private:
   	std::size_t concat_cache_num_bytes;
+	int num_bytes_timeout;
 	bool concat_all;
 
 };

--- a/engine/src/execution_graph/logic_controllers/PhysicalPlanGenerator.h
+++ b/engine/src/execution_graph/logic_controllers/PhysicalPlanGenerator.h
@@ -382,6 +382,11 @@ struct tree_processor {
 			if (it != config_options.end()){
 				join_partition_size_thresh = std::stoull(config_options["JOIN_PARTITION_SIZE_THRESHOLD"]);
 			}
+			int concatenating_cache_num_bytes_timeout = 100000; // 100ms
+			it = config_options.find("CONCATENATING_CACHE_NUM_BYTES_TIMEOUT");
+			if (it != config_options.end()){
+				concatenating_cache_num_bytes_timeout = std::stoi(config_options["CONCATENATING_CACHE_NUM_BYTES_TIMEOUT"]);
+			}
 			
 			auto child_kernel_type = child->kernel_unit->get_type_id();
 			auto parent_kernel_type = parent->kernel_unit->get_type_id();
@@ -397,7 +402,7 @@ struct tree_processor {
 					bool right_concat_all = join_type == ral::batch::LEFT_JOIN || join_type == ral::batch::OUTER_JOIN || join_type == ral::batch::CROSS_JOIN;
 					bool concat_all = index == 0 ? left_concat_all : right_concat_all;
 					cache_settings join_cache_machine_config = cache_settings{.type = CacheType::CONCATENATING, .num_partitions = 1, .context = context->clone(),
-						.concat_cache_num_bytes = join_partition_size_thresh, .concat_all = concat_all};
+						.concat_cache_num_bytes = join_partition_size_thresh, .num_bytes_timeout = concatenating_cache_num_bytes_timeout, .concat_all = concat_all};
 					query_graph.addPair(ral::cache::kpair(child->kernel_unit, parent->kernel_unit, port_name, join_cache_machine_config));					
 
 				} else {
@@ -414,9 +419,9 @@ struct tree_processor {
 					bool left_concat_all = join_type == ral::batch::RIGHT_JOIN || join_type == ral::batch::OUTER_JOIN || join_type == ral::batch::CROSS_JOIN;
 					bool right_concat_all = join_type == ral::batch::LEFT_JOIN || join_type == ral::batch::OUTER_JOIN || join_type == ral::batch::CROSS_JOIN;
 					cache_settings left_cache_machine_config = cache_settings{.type = CacheType::CONCATENATING, .num_partitions = 1, .context = context->clone(),
-						.concat_cache_num_bytes = join_partition_size_thresh, .concat_all = left_concat_all};
+						.concat_cache_num_bytes = join_partition_size_thresh, .num_bytes_timeout = concatenating_cache_num_bytes_timeout, .concat_all = left_concat_all};
 					cache_settings right_cache_machine_config = cache_settings{.type = CacheType::CONCATENATING, .num_partitions = 1, .context = context->clone(),
-						.concat_cache_num_bytes = join_partition_size_thresh, .concat_all = right_concat_all};
+						.concat_cache_num_bytes = join_partition_size_thresh, .num_bytes_timeout = concatenating_cache_num_bytes_timeout, .concat_all = right_concat_all};
 					
 					query_graph.addPair(ral::cache::kpair(child->kernel_unit, "output_a", parent->kernel_unit, "input_a", left_cache_machine_config));
 					query_graph.addPair(ral::cache::kpair(child->kernel_unit, "output_b", parent->kernel_unit, "input_b", right_cache_machine_config));
@@ -453,7 +458,7 @@ struct tree_processor {
 					}
 					
 					cache_settings cache_machine_config = cache_settings{.type = CacheType::CONCATENATING, .num_partitions = 1, .context = context->clone(),
-						.concat_cache_num_bytes = concat_cache_num_bytes, .concat_all = false};
+						.concat_cache_num_bytes = concat_cache_num_bytes, .num_bytes_timeout = concatenating_cache_num_bytes_timeout, .concat_all = false};
 					query_graph.addPair(ral::cache::kpair(child->kernel_unit, parent->kernel_unit, cache_machine_config));
 				} else {
 					cache_settings cache_machine_config;

--- a/engine/src/execution_graph/logic_controllers/WaitingQueue.h
+++ b/engine/src/execution_graph/logic_controllers/WaitingQueue.h
@@ -245,11 +245,15 @@ public:
 	* batch.
 	* @param num_bytes The number of bytes that we will wait to exist in the
 	* WaitingQueue unless the WaitingQueue has already had finished() called.
+	* @param num_bytes_timeout A timeout in ms where if there is data and the timeout 
+	* expires, then it will return, even if not the requested num_bytes is available.
+	* If its set to -1, then it disables this timeout
 	*/
-	void wait_until_num_bytes(size_t num_bytes) {
+	void wait_until_num_bytes(size_t num_bytes, int num_bytes_timeout = -1) {
 		CodeTimer blazing_timer;
 		std::unique_lock<std::mutex> lock(mutex_);
-		while(!condition_variable_.wait_for(lock, timeout*1ms, [&blazing_timer, num_bytes, this] {
+		int cond_var_timeout = (num_bytes_timeout > -1 && num_bytes_timeout < timeout) ? num_bytes_timeout : timeout;
+		while(!condition_variable_.wait_for(lock, timeout*1ms, [&blazing_timer, num_bytes, num_bytes_timeout, this] {
 				bool done_waiting = this->finished.load(std::memory_order_seq_cst);
 				size_t total_bytes = 0;
 				if (!done_waiting) {					
@@ -257,6 +261,9 @@ public:
 						total_bytes += message->get_data().sizeInBytes();
 					}
 					done_waiting = total_bytes > num_bytes;
+				}
+				if (!done_waiting && total_bytes > 0 && num_bytes_timeout > -1) {
+					done_waiting = blazing_timer.elapsed_time() > num_bytes_timeout;
 				}
 				if (!done_waiting && blazing_timer.elapsed_time() > 59000 && this->log_timeout){
                     std::shared_ptr<spdlog::logger> logger = spdlog::get("batch_logger");

--- a/engine/src/execution_graph/logic_controllers/WaitingQueue.h
+++ b/engine/src/execution_graph/logic_controllers/WaitingQueue.h
@@ -253,7 +253,7 @@ public:
 		CodeTimer blazing_timer;
 		std::unique_lock<std::mutex> lock(mutex_);
 		int cond_var_timeout = (num_bytes_timeout > -1 && num_bytes_timeout < timeout) ? num_bytes_timeout : timeout;
-		while(!condition_variable_.wait_for(lock, timeout*1ms, [&blazing_timer, num_bytes, num_bytes_timeout, this] {
+		while(!condition_variable_.wait_for(lock, cond_var_timeout*1ms, [&blazing_timer, num_bytes, num_bytes_timeout, this] {
 				bool done_waiting = this->finished.load(std::memory_order_seq_cst);
 				size_t total_bytes = 0;
 				if (!done_waiting) {					

--- a/engine/src/execution_graph/logic_controllers/taskflow/graph.h
+++ b/engine/src/execution_graph/logic_controllers/taskflow/graph.h
@@ -16,7 +16,7 @@ static std::shared_ptr<ral::cache::CacheMachine> create_cache_machine( const cac
 		machine =  std::make_shared<ral::cache::CacheMachine>(config.context, cache_machine_name);
 	} else if (config.type == CacheType::CONCATENATING) {
 		machine =  std::make_shared<ral::cache::ConcatenatingCacheMachine>(config.context, 
-			config.concat_cache_num_bytes, config.concat_all, cache_machine_name);
+			config.concat_cache_num_bytes, config.num_bytes_timeout, config.concat_all, cache_machine_name);
 	}
 	return machine;
 }

--- a/engine/src/execution_graph/logic_controllers/taskflow/kpair.h
+++ b/engine/src/execution_graph/logic_controllers/taskflow/kpair.h
@@ -19,7 +19,8 @@ struct cache_settings {
 	CacheType type = CacheType::SIMPLE;
 	int num_partitions = 1;
 	std::shared_ptr<Context> context;
-	std::size_t concat_cache_num_bytes = 400000000;
+	std::size_t concat_cache_num_bytes = 400000000;  ///< Applicable only for concatenating caches
+	int num_bytes_timeout = 100000;  ///< Applicable only for concatenating caches
 	bool concat_all = false; ///< Applicable only for concatenating caches
 };
 

--- a/engine/src/execution_graph/logic_controllers/taskflow/kpair.h
+++ b/engine/src/execution_graph/logic_controllers/taskflow/kpair.h
@@ -20,7 +20,7 @@ struct cache_settings {
 	int num_partitions = 1;
 	std::shared_ptr<Context> context;
 	std::size_t concat_cache_num_bytes = 400000000;  ///< Applicable only for concatenating caches
-	int num_bytes_timeout = 100000;  ///< Applicable only for concatenating caches
+	int num_bytes_timeout = 100;  ///< Applicable only for concatenating caches
 	bool concat_all = false; ///< Applicable only for concatenating caches
 };
 

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -1195,7 +1195,7 @@ def load_config_options_from_env(user_config_options: dict):
     config_options = {}
     default_values = {
         "JOIN_PARTITION_SIZE_THRESHOLD": 400000000,
-        "CONCATENATING_CACHE_NUM_BYTES_TIMEOUT": 100000,
+        "CONCATENATING_CACHE_NUM_BYTES_TIMEOUT": 100,
         "MAX_JOIN_SCATTER_MEM_OVERHEAD": 500000000,
         "MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE": 8,
         "NUM_BYTES_PER_ORDER_BY_PARTITION": 400000000,
@@ -1311,7 +1311,7 @@ class BlazingContext(object):
                     default: 400000000
             CONCATENATING_CACHE_NUM_BYTES_TIMEOUT : Time in ms to wait to try to 
                     have the bytes desired in a ConcatenatingCacheMachine.
-                    default: 100000 (100 ms)
+                    default: 100 (100 ms)
             MAX_JOIN_SCATTER_MEM_OVERHEAD : The bigger this value, the more
                     likely one of the tables of join will be scattered to all
                     the nodes, instead of doing a standard hash based

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -1309,7 +1309,7 @@ class BlazingContext(object):
                     Too small can lead to overpartitioning, too big can lead
                     to OOM errors.
                     default: 400000000
-            CONCATENATING_CACHE_NUM_BYTES_TIMEOUT : Time in ms to wait to try to 
+            CONCATENATING_CACHE_NUM_BYTES_TIMEOUT : Time in ms to wait to try to
                     have the bytes desired in a ConcatenatingCacheMachine.
                     default: 100 (100 ms)
             MAX_JOIN_SCATTER_MEM_OVERHEAD : The bigger this value, the more

--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -1195,6 +1195,7 @@ def load_config_options_from_env(user_config_options: dict):
     config_options = {}
     default_values = {
         "JOIN_PARTITION_SIZE_THRESHOLD": 400000000,
+        "CONCATENATING_CACHE_NUM_BYTES_TIMEOUT": 100000,
         "MAX_JOIN_SCATTER_MEM_OVERHEAD": 500000000,
         "MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE": 8,
         "NUM_BYTES_PER_ORDER_BY_PARTITION": 400000000,
@@ -1308,6 +1309,9 @@ class BlazingContext(object):
                     Too small can lead to overpartitioning, too big can lead
                     to OOM errors.
                     default: 400000000
+            CONCATENATING_CACHE_NUM_BYTES_TIMEOUT : Time in ms to wait to try to 
+                    have the bytes desired in a ConcatenatingCacheMachine.
+                    default: 100000 (100 ms)
             MAX_JOIN_SCATTER_MEM_OVERHEAD : The bigger this value, the more
                     likely one of the tables of join will be scattered to all
                     the nodes, instead of doing a standard hash based


### PR DESCRIPTION
Resolves #1414 

This PR introduces a time out to ConcatenatingCacheMachine, so that it will either wait to accumulate a certain number of bytes, or for a timeout (which is configurable) or for the CacheMachine to `finish()`.  