### PR TITLE
Update ucx-py versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - #1548 Fix orc statistic building
 - #1550 Fix Decimal/Fixed Point issue
 - #1519 Fix for max_bytes_chunk_read param to csv files
+- #1559 Fix `ucx-py` versioning specs
 
 
 # BlazingSQL 0.19.0 (April 21, 2021)

--- a/build.sh
+++ b/build.sh
@@ -95,6 +95,7 @@ fi
 # Get version number
 export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
+export UCX_PY_VERSION="0.20"
 
 # Process flags
 if hasArg -v; then
@@ -163,7 +164,7 @@ fi
 ################################################################################
 
 if hasArg update; then
-    conda install --yes -c rapidsai-nightly -c nvidia -c conda-forge -c defaults librmm=$MINOR_VERSION rmm=$MINOR_VERSION libcudf=$MINOR_VERSION cudf=$MINOR_VERSION dask-cudf=$MINOR_VERSION dask-cuda=$MINOR_VERSION ucx-py=$MINOR_VERSION ucx-proc=*=gpu
+    conda install --yes -c rapidsai-nightly -c nvidia -c conda-forge -c defaults librmm=$MINOR_VERSION rmm=$MINOR_VERSION libcudf=$MINOR_VERSION cudf=$MINOR_VERSION dask-cudf=$MINOR_VERSION dask-cuda=$MINOR_VERSION ucx-py=$UCX_PY_VERSION ucx-proc=*=gpu
 fi
 
 ################################################################################

--- a/conda/recipes/blazingsql/meta.yaml
+++ b/conda/recipes/blazingsql/meta.yaml
@@ -36,7 +36,7 @@ requirements:
         - openjdk >=8.0, <9.0
         - maven
         - cudf {{ minor_version }}.*
-        - ucx-py {{ minor_version }}.*
+        - ucx-py 0.20.*
         - ucx-proc=*=gpu
         - boost-cpp 1.72.0
         - dlpack
@@ -55,7 +55,7 @@ requirements:
         - {{ pin_compatible('zeromq', max_pin='x.x.x') }}
         - dask-cudf {{ minor_version }}.*
         - dask-cuda {{ minor_version }}.*
-        - ucx-py {{ minor_version }}.*
+        - ucx-py 0.20.*
         - ucx-proc=*=gpu
         - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
         - tqdm

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,6 +11,7 @@ ITALICRED="\e[3;${RED}"
 ENDCOLOR="\e[0m"
 
 RAPIDS_VERSION="21.06"
+UCX_PY_VERSION="0.20"
 CUDA_VERSION="11.0"
 CHANNEL=""
 
@@ -33,7 +34,7 @@ conda install --yes -c conda-forge cmake=3.18 gtest==1.10.0=h0efe328_4 gmock cpp
 
 
 echo -e "${GREEN}Install RAPIDS dependencies${ENDCOLOR}"
-conda install --yes -c rapidsai$CHANNEL -c nvidia -c conda-forge -c defaults dask-cuda=$RAPIDS_VERSION dask-cudf=$RAPIDS_VERSION cudf=$RAPIDS_VERSION ucx-py=$RAPIDS_VERSION ucx-proc=*=gpu cudatoolkit=$CUDA_VERSION
+conda install --yes -c rapidsai$CHANNEL -c nvidia -c conda-forge -c defaults dask-cuda=$RAPIDS_VERSION dask-cudf=$RAPIDS_VERSION cudf=$RAPIDS_VERSION ucx-py=$UCX_PY_VERSION ucx-proc=*=gpu cudatoolkit=$CUDA_VERSION
 
 echo -e "${GREEN}Install E2E test dependencies${ENDCOLOR}"
 


### PR DESCRIPTION
This PR updates the `ucx-py` versions used by Blazing. `ucx-py` will not be switching to calendar versioning like the rest of RAPIDS, so their versions must be updated accordingly (similar to https://github.com/rapidsai/cuml/pull/3911 and https://github.com/rapidsai/cugraph/pull/1634).

For now I've hard-coded the values here to help unblock some RAPIDS builds, but I will update Blazing accordingly if we set up any automation here.