### PR TITLE
[REVIEW] Fix `CC`/`CXX` variables in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 
 ## Bug Fixes
-- #1570 Fix build due to changes in rmm device buffer 
+- #1570 Fix build due to changes in rmm device buffer
+- #1576 Fix `CC`/`CXX` variables in CI
 
 
 # BlazingSQL 21.06.00 (June 10th, 2021)

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -44,8 +44,8 @@ conda activate rapids
 
 gpuci_logger "Check versions"
 python --version
-gcc --version
-g++ --version
+$CC --version
+$CXX --version
 
 gpuci_logger "Conda Information"
 conda info

--- a/conda/recipes/blazingsql/meta.yaml
+++ b/conda/recipes/blazingsql/meta.yaml
@@ -17,6 +17,7 @@ build:
       - PARALLEL_LEVEL
       - CUDA_VERSION
       - CUDACXX
+      - CUDAHOSTCXX
       - CC
       - CXX
 

--- a/conda/recipes/blazingsql/meta.yaml
+++ b/conda/recipes/blazingsql/meta.yaml
@@ -17,6 +17,8 @@ build:
       - PARALLEL_LEVEL
       - CUDA_VERSION
       - CUDACXX
+      - CC
+      - CXX
 
 requirements:
     build:
@@ -77,4 +79,4 @@ about:
     home: http://www.blazingsql.com/
     license: Apache-2.0
     license_family: Apache
-    summary: GPU-powered distributed SQL engine in Python 
+    summary: GPU-powered distributed SQL engine in Python

--- a/engine/src/io/data_parser/ArgsUtil.cpp
+++ b/engine/src/io/data_parser/ArgsUtil.cpp
@@ -112,7 +112,7 @@ cudf::io::orc_reader_options getOrcReaderOptions(const std::map<std::string, std
 
 	cudf::io::orc_reader_options reader_opts = cudf::io::orc_reader_options::builder(cudf::io::source_info{&arrow_source});
 	if(map_contains("stripes", args)) {
-		reader_opts.set_stripes(to_vector_int(args.at("stripes")));
+		reader_opts.set_stripes({to_vector_int(args.at("stripes"))});
 	}
 	if(map_contains("skiprows", args)) {
 		reader_opts.set_skip_rows(to_int(args.at("skiprows")));

--- a/engine/src/io/data_parser/OrcParser.cpp
+++ b/engine/src/io/data_parser/OrcParser.cpp
@@ -41,7 +41,7 @@ std::unique_ptr<ral::frame::BlazingTable> orc_parser::parse_batch(
 		}
 
 		orc_opts.set_columns(col_names);
-		orc_opts.set_stripes(row_groups);
+		orc_opts.set_stripes({row_groups});
 
 		auto result = cudf::io::read_orc(orc_opts);
 

--- a/engine/src/parser/expression_utils.cpp
+++ b/engine/src/parser/expression_utils.cpp
@@ -1166,12 +1166,35 @@ std::string fill_minus_op_with_zero(std::string expression) {
 // input: CONCAT($0, ' - ', CAST($1):VARCHAR, ' : ', $2)
 // output: "CONCAT(CONCAT(CONCAT(CONCAT($0, ' - '), CAST($1):VARCHAR), ' : '), $2)"
 std::string convert_concat_expression_into_multiple_binary_concat_ops(std::string expression) {
-	if (expression.find("CONCAT") == expression.npos) {
+	size_t start_concat_pos = expression.find("CONCAT(");
+	if (start_concat_pos == expression.npos) {
 		return expression;
 	}
 
+	std::string concat_expression;
+	bool start_with_concat = false;
+	if (start_concat_pos != 0) {
+		// Let's find out how many `(` there are before `CONCAT`
+		std::string left_expression = expression.substr(0, start_concat_pos);
+		size_t total_open_parenth = StringUtil::findAndCountAllMatches(left_expression, "(");
+
+		std::string reverse_expression(expression);
+		std::reverse(reverse_expression.begin(), reverse_expression.end());
+
+		size_t offset = 0;
+		for (size_t i = 0; i <= total_open_parenth; ++i) {
+			size_t closed_parenth_pos = reverse_expression.find(")");
+			offset += closed_parenth_pos;
+			reverse_expression = reverse_expression.substr(closed_parenth_pos + 1, expression.size() - (closed_parenth_pos + 1));
+		}
+		concat_expression = expression.substr(start_concat_pos, expression.size() - offset - start_concat_pos - 1);
+	} else {
+		start_with_concat = true;
+		concat_expression = expression;
+	}
+
 	// just to remove `CONCAT( )`
-	std::string expression_wo_concat = get_query_part(expression);
+	std::string expression_wo_concat = get_query_part(concat_expression);
 	std::vector<std::string> expressions_to_concat = get_expressions_from_expression_list(expression_wo_concat);
 
 	if (expressions_to_concat.size() < 2) throw std::runtime_error("CONCAT operator must have at least two children, as CONCAT($0, $1) .");
@@ -1182,7 +1205,14 @@ std::string convert_concat_expression_into_multiple_binary_concat_ops(std::strin
 		new_expression = "CONCAT(" + new_expression + ", " + expressions_to_concat[i] + ")";
 	}
 
-	return new_expression;
+	std::string output_expression;
+	if (start_with_concat) {
+		output_expression = new_expression;
+	} else {
+		output_expression = StringUtil::replace(expression, concat_expression, new_expression);
+	}
+
+	return output_expression;
 }
 
 const std::string remove_quotes_from_timestamp_literal(const std::string & scalar_string) {

--- a/engine/tests/parser/expression_utils_test.cpp
+++ b/engine/tests/parser/expression_utils_test.cpp
@@ -331,6 +331,23 @@ TEST_F(ExpressionUtilsTest, concat_operator_using_comma_as_literal)
 	EXPECT_EQ(out_expression, expected_str);
 }
 
+TEST_F(ExpressionUtilsTest, concat_operator_inside_a_like_operator)
+{
+	std::string expression = "LIKE(CONCAT('Customer#000000', $0), 'Customer#0000001')";
+	std::string out_expression = convert_concat_expression_into_multiple_binary_concat_ops(expression);
+
+	EXPECT_EQ(out_expression, expression);
+}
+
+TEST_F(ExpressionUtilsTest, multiple_concat_operator_inside_a_like_operator)
+{
+	std::string expression = "LIKE(CONCAT('abcd', '0000', $0), '001')";
+	std::string out_expression = convert_concat_expression_into_multiple_binary_concat_ops(expression);
+	std::string expected_str = "LIKE(CONCAT(CONCAT('abcd', '0000'), $0), '001')";
+
+	EXPECT_EQ(out_expression, expected_str);
+}
+
 TEST_F(ExpressionUtilsTest, replace_is_not_distinct_as_calcite__empty)
 {
 	std::string expression = "";


### PR DESCRIPTION
This PR adds `CC`, `CXX`, and `CUDAHOSTCXX` entries to the `build.script_env` section of the `conda` recipe, so that those environment variables get passed through the `build.sh` script and ultimately to CMake. This enables CMake to use the correct versions of `gcc` and `g++` when compiling.

Additionally, it includes some fixes for the upstream cudf changes in https://github.com/rapidsai/cudf/pull/8142