### PR TITLE
Fix CI Environment Variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - #1581 Fix latest cudf dependencies
 - #1582 Fix concat suite E2E test for nested calls
 - #1585 Fix for GCS credentials from filepath
+- #1586 Fix CI Environment Variable
 
 
 # BlazingSQL 21.06.00 (June 10th, 2021)

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -42,7 +42,7 @@ gpuci_logger "Check GPU usage"
 nvidia-smi
 
 gpuci_logger "Activate conda env"
-conda create python=$PYTHON_VER -y -n bsql
+conda create python=$PYTHON_VERSION -y -n bsql
 source activate bsql
 conda config --set ssl_verify False
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -2,6 +2,7 @@
 #
 # This script install BlazingSQL dependencies based on rapids version
 #
+set -e
 echo "Usage: ./$0 rapids_version cuda_version nightly"
 
 export GREEN='\033[0;32m'


### PR DESCRIPTION
This PR updates the `$PYTHON_VER` environment variable to be `$PYTHON_VERSION` since that's the variable name that's used in the CI job here: https://gpuci.gpuopenanalytics.com/job/blazingsql/job/gpuci/job/blazingsql/job/branches/job/blazingsql-gpu-matrix-branch-21.08/

This should fix some of the latest build failures for that job.

Also, this PR adds a `set -e` to `dependencies.sh` to ensure that it exits if the dependencies don't install correctly. This is to prevent the script from continuing to run if there are conflicts during the `conda install` steps (which happened in [this build log](https://gpuci.gpuopenanalytics.com/job/blazingsql/job/gpuci/job/blazingsql/job/branches/job/blazingsql-gpu-matrix-branch-21.08/44/CUDA=11.2,LINUX_VER=ubuntu18.04,PYTHON_VERSION=3.7/console))