### PR TITLE
[REVIEW] Add argument thrust-ignore-cub-version-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - #1582 Fix concat suite E2E test for nested calls
 - #1585 Fix for GCS credentials from filepath
 - #1589 Fix decimal support using float64
-
+- #1590 Fix build issue with thrust package
 
 # BlazingSQL 21.06.00 (June 10th, 2021)
 

--- a/engine/setup.py
+++ b/engine/setup.py
@@ -82,6 +82,7 @@ extensions = [
                             "-Wno-unknown-pragmas",
                             "-Wno-unused-variable",
                             "-Wno-unused-function",
+                            "-DTHRUST_IGNORE_CUB_VERSION_CHECK",
                             '-isystem' + conda_env_inc,
                             '-isystem' + conda_env_inc_cudf,
                             '-isystem' + conda_env_inc_cub,


### PR DESCRIPTION
Changes:
1. Add compile argument thrust-ignore-cub-version-check in order to fix build issue