### PR TITLE
Pin spdlog to match RAPIDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - #1585 Fix for GCS credentials from filepath
 - #1589 Fix decimal support using float64
 - #1590 Fix build issue with thrust package
+- #1595 Fix `spdlog` pinning
 
 # BlazingSQL 21.06.00 (June 10th, 2021)
 

--- a/conda/recipes/blazingsql/meta.yaml
+++ b/conda/recipes/blazingsql/meta.yaml
@@ -34,7 +34,7 @@ requirements:
         - cppzmq
         - python
         - setuptools
-        - spdlog >=1.8.5,<2.0.0a0
+        - spdlog >=1.8.5,<1.9
         - cython >=0.29,<0.30
         - openjdk >=8.0, <9.0
         - maven
@@ -54,7 +54,7 @@ requirements:
         - netifaces
         - pyhive
         - sqlite 3
-        - spdlog >=1.8.5,<2.0.0a0
+        - spdlog >=1.8.5,<1.9
         - {{ pin_compatible('zeromq', max_pin='x.x.x') }}
         - dask-cudf {{ minor_version }}.*
         - dask-cuda {{ minor_version }}.*


### PR DESCRIPTION
There is a conda solver conflict due to BlazingSQL using a higher version of `spdlog` than the rest of RAPIDS. This PR simply pins `spdlog` to the same as [`librmm`](https://github.com/rapidsai/rmm/blob/branch-21.08/conda/recipes/librmm/meta.yaml#L38).