### PR TITLE
Restrict Google cloud cpp version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - #1589 Fix decimal support using float64
 - #1590 Fix build issue with thrust package
 - #1595 Fix `spdlog` pinning
+- #1597 Fix `google-cloud-cpp` pinning
 
 # BlazingSQL 21.06.00 (June 10th, 2021)
 

--- a/conda/recipes/blazingsql/meta.yaml
+++ b/conda/recipes/blazingsql/meta.yaml
@@ -27,7 +27,7 @@ requirements:
         - ninja
         - gtest 1.10
         - aws-sdk-cpp
-        - google-cloud-cpp >=1.25.0
+        - google-cloud-cpp >=1.25.0,<1.30
         - mysql-connector-cpp 8.0.23
         - libpq 13
         - nlohmann_json 3.9.1

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -28,7 +28,7 @@ if [ ! -z $3 ]; then
 fi
 
 echo -e "${GREEN}Installing dependencies${ENDCOLOR}"
-conda install --yes -c conda-forge spdlog'>=1.8.5,<2.0.0a0' google-cloud-cpp'>=1.25' ninja mysql-connector-cpp=8.0.23 libpq=13 nlohmann_json=3.9.1
+conda install --yes -c conda-forge spdlog'>=1.8.5,<1.9' google-cloud-cpp'>=1.25,<1.30' ninja mysql-connector-cpp=8.0.23 libpq=13 nlohmann_json=3.9.1
 # NOTE cython must be the same of cudf (for 0.11 and 0.12 cython is >=0.29,<0.30)
 conda install --yes -c conda-forge cmake=3.18 gtest==1.10.0=h0efe328_4 gmock cppzmq cython=0.29 openjdk'>=8.0,<9.0' maven jpype1 netifaces pyhive pytest tqdm ipywidgets boost-cpp=1.72.0
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -34,7 +34,7 @@ conda install --yes -c conda-forge cmake=3.18 gtest==1.10.0=h0efe328_4 gmock cpp
 
 
 echo -e "${GREEN}Install RAPIDS dependencies${ENDCOLOR}"
-conda install --yes -c rapidsai$CHANNEL -c nvidia -c conda-forge -c defaults dask-cuda=$RAPIDS_VERSION dask-cudf=$RAPIDS_VERSION cudf=$RAPIDS_VERSION ucx-py=$UCX_PY_VERSION ucx-proc=*=gpu cudatoolkit=$CUDA_VERSION
+conda install --yes -c rapidsai$CHANNEL -c nvidia -c conda-forge -c defaults dask-cuda=$RAPIDS_VERSION dask-cudf=$RAPIDS_VERSION cudf=$RAPIDS_VERSION "rapidsai$CHANNEL::librmm=$RAPIDS_VERSION" ucx-py=$UCX_PY_VERSION ucx-proc=*=gpu cudatoolkit=$CUDA_VERSION
 
 echo -e "${GREEN}Install E2E test dependencies${ENDCOLOR}"
 


### PR DESCRIPTION
Starting with `google-cloud-cpp>=1.30`, it requires `libgcc-ng>=9.4.0` which is not compatible with RAPIDS. RAPIDS requires `libgcc-ng==9.3.0`.

I've testing this build and install with RAPIDS `21.08` locally and it works with this change.